### PR TITLE
Add failed import recovery tools

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,69 @@
+# Granola Importer Plugin for Obsidian
+
+## Project Overview
+
+This project is an Obsidian plugin that allows users to import their notes from Granola, an AI-powered notepad for meetings. The plugin is written in TypeScript and uses the Obsidian API to interact with the Obsidian environment. It preserves the formatting of the original notes by converting them from ProseMirror JSON to Markdown.
+
+The plugin features:
+
+- One-click import of all Granola notes
+- Secure credential management
+- Smart conflict resolution for existing notes
+- Selective import with document preview and filtering
+- Customizable filename templates
+- Attendee tagging from meeting participants
+- Direct Granola links in frontmatter for cross-referencing
+- Action items conversion to Obsidian tasks
+
+## Building and Running
+
+### Build
+
+To build the plugin, run the following command:
+
+```bash
+npm run build
+```
+
+This will compile the TypeScript code and create the `main.js`, `manifest.json`, and `styles.css` files in the project's root directory.
+
+### Run
+
+To run the plugin in a development environment, use the following command:
+
+```bash
+npm run dev
+```
+
+This will start a development server that watches for changes in the source code and automatically rebuilds the plugin.
+
+### Test
+
+To run the tests for the plugin, use the following command:
+
+```bash
+npm test
+```
+
+This will run all the tests in the `tests/` directory.
+
+## Development Conventions
+
+### Coding Style
+
+The project uses Prettier for code formatting and ESLint for linting. The coding style is enforced by pre-commit hooks that run Prettier and ESLint before each commit.
+
+### Testing Practices
+
+The project uses Jest for testing. The tests are located in the `tests/` directory and are organized into unit and integration tests. The tests are run automatically on each commit by a pre-commit hook.
+
+### Contribution Guidelines
+
+To contribute to the project, you should:
+
+1. Fork the repository
+2. Create a feature branch
+3. Run `./setup-hooks.sh` to enable pre-commit hooks
+4. Follow the existing code patterns
+5. Ensure all tests pass: `npm test && npm run lint && npm run build`
+6. Submit a pull request

--- a/QWEN.md
+++ b/QWEN.md
@@ -141,7 +141,7 @@ The plugin provides intelligent duplicate detection and resolution:
 
 ## Project Structure
 
-```
+```text
 obsidian-granola/
 ├── src/
 │   ├── services/          # Core business logic (import manager, duplicate detection)

--- a/QWEN.md
+++ b/QWEN.md
@@ -1,0 +1,186 @@
+# Granola Importer Plugin for Obsidian - Project Context
+
+## Project Overview
+
+The Granola Importer is a sophisticated Obsidian plugin that enables users to import their Granola AI notes into Obsidian with perfect formatting preservation. Granola is an AI notepad for people in back-to-back meetings that enhances raw meeting notes using AI, and this plugin bridges the two platforms by importing documents with rich formatting, metadata, and structural elements intact.
+
+### Key Features
+
+- One-click import of all Granola notes
+- Perfect formatting preservation from ProseMirror to Markdown
+- Secure credential management with automatic detection
+- Smart conflict resolution for existing notes
+- Selective import with document preview and filtering
+- Cross-platform support (macOS, Windows, Linux)
+- Customizable filename templates with date/time variables
+- Attendee tagging from meeting participants
+- Direct Granola links in frontmatter for cross-referencing
+- Action items conversion to Obsidian tasks
+
+### Technologies & Architecture
+
+**Core Technologies:**
+
+- TypeScript for type-safe development
+- Obsidian API for plugin integration
+- ProseMirror JSON format handling
+- esbuild for bundling
+- OAuth 2.0 with AWS Cognito for authentication
+
+**Key Architecture Components:**
+
+1. **GranolaAuth** - Handles credential loading and validation from platform-specific locations
+2. **GranolaAPI** - HTTP client with retry logic and batch processing for API communication
+3. **ProseMirrorConverter** - Converts ProseMirror JSON to Markdown with advanced formatting support
+4. **Document Selection Modal** - UI for previewing and selecting documents to import
+5. **Import Manager** - Batch processing with progress tracking and error handling
+6. **Conflict Resolution Modal** - Handles duplicate and conflicting document scenarios
+7. **Settings System** - Comprehensive configuration for import behavior, naming, and processing
+
+## Building and Running
+
+### Development Setup
+
+```bash
+git clone https://github.com/amittell/obsidian-granola.git
+cd obsidian-granola
+npm install
+./setup-hooks.sh  # Enable pre-commit hooks
+npm run dev       # Start development in watch mode
+```
+
+### Build Commands
+
+- `npm run dev` - Watch mode with hot reload
+- `npm run build` - Production build
+- `npm run test` - Run all tests
+- `npm run lint` - Run ESLint
+- `npm run format` - Auto-format code with Prettier
+- `npm run type-check` - TypeScript type checking
+
+### Deployment
+
+- The plugin is built to a single `main.js` file using esbuild
+- Production builds are minified with advanced optimizations
+- Bundle analysis is available with `npm run analyze`
+
+## Development Conventions
+
+### Code Style
+
+- TypeScript strict mode with comprehensive type checking
+- ESLint with custom rules for consistency
+- Prettier for code formatting
+- JSDoc comments for all public APIs
+- Comprehensive error handling and logging
+
+### Git Hooks
+
+- Pre-commit hooks enforce code quality (formatting, linting, building)
+- Hooks run only on changed files for fast feedback
+- Bypass with `git commit --no-verify` when necessary
+
+### Testing
+
+- Jest for unit and integration tests
+- Code coverage reporting
+- CI mode for continuous integration
+
+### Security & Privacy
+
+- No credential storage in the plugin - reads directly from Granola's secure storage
+- No token logging to console or logs
+- Secure error handling that doesn't expose sensitive data
+- Local processing - all conversion happens on the user's machine
+
+## Technical Details
+
+### API Integration
+
+The plugin connects to the Granola API at `https://api.granola.ai/v2/get-documents` using OAuth 2.0 with AWS Cognito tokens. Credentials are automatically discovered from platform-specific locations:
+
+- macOS: `~/Library/Application Support/Granola/supabase.json`
+- Windows: `%APPDATA%/Granola/supabase.json`
+- Linux: `~/.config/Granola/supabase.json`
+
+### Content Conversion
+
+The plugin handles multiple content formats in priority order:
+
+1. `last_viewed_panel.content` (ProseMirror JSON or HTML)
+2. `notes.content` (legacy ProseMirror JSON)
+3. `notes_markdown` (pre-converted markdown)
+4. `notes_plain` (plain text fallback)
+
+### ProseMirror to Markdown Conversion
+
+The converter handles a wide range of content types:
+
+- Text formatting (bold, italic, code, links)
+- Structural elements (headings, paragraphs, lists)
+- Advanced content (code blocks, blockquotes, tables, horizontal rules)
+- Nested structures and complex hierarchies
+- Action items that can be converted to Obsidian tasks
+
+### Conflict Handling
+
+The plugin provides intelligent duplicate detection and resolution:
+
+- Skip, update, or rename existing documents
+- Backup creation when overwriting
+- Merge options with append/prepend strategies
+- Advanced conflict resolution UI
+
+### UI Components
+
+- Document selection modal with preview functionality
+- Progress tracking with real-time feedback
+- Conflict resolution with multiple options
+- Settings interface with comprehensive options
+- Ribbon icon for quick access
+
+## Project Structure
+
+```
+obsidian-granola/
+├── src/
+│   ├── services/          # Core business logic (import manager, duplicate detection)
+│   ├── ui/               # User interface components (modals, views)
+│   ├── utils/            # Helper functions and utilities
+│   ├── styles/           # CSS styling
+│   ├── api.ts            # API client and data types
+│   ├── auth.ts           # Authentication and credential management
+│   ├── converter.ts      # ProseMirror to Markdown conversion
+│   ├── settings.ts       # Settings UI implementation
+│   └── types.ts          # Type definitions and interfaces
+├── main.ts               # Plugin entry point and main class
+├── esbuild.config.mjs    # Build configuration
+├── package.json          # Dependencies and scripts
+├── README.md             # User documentation
+└── granola-api.md        # API documentation
+```
+
+## Plugin Settings
+
+Comprehensive configuration options include:
+
+- Connection validation and testing
+- Debug logging with multiple levels
+- Import behavior (duplicate handling, default folder)
+- Content processing (filename templates, enhanced frontmatter)
+- Action item processing (task conversion, task tagging)
+- Attendee tag extraction and formatting
+- UI preferences (notifications, ribbon icon)
+
+## Development Notes
+
+This plugin is designed with a focus on reliability, user experience, and security. Key design decisions include:
+
+- Reading credentials from the user's existing Granola installation rather than handling authentication
+- Comprehensive error handling and logging for debugging complex issues
+- Flexible conflict resolution to handle various import scenarios
+- Performance optimization with batch processing and progress tracking
+- Rich UI for document selection and conflict resolution
+- Platform-specific credential detection for cross-platform compatibility
+
+The plugin follows Obsidian plugin best practices and maintains high code quality with extensive type safety, comprehensive testing, and proper error handling.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ When you run the import command, the plugin will:
    - Success/failure indicators
    - Detailed error messages if issues occur
 
+#### Recovering Failed Imports
+
+When a document can't be imported, the completion summary now helps you recover quickly:
+
+- **Retry failed imports** with a single click—only the documents that failed are retried, using the same import settings and live progress view.
+- **Export the failure list** for troubleshooting via the new dropdown:
+  - Download a CSV with document ID, title, error reason, and timestamp.
+  - Copy a formatted summary to your clipboard for sharing with support or teammates.
+- **Keep working seamlessly**—successful documents remain available to open immediately while retries and exports focus solely on the failures.
+
 ### Common Use Cases
 
 #### Daily Meeting Notes

--- a/src/services/import-manager.ts
+++ b/src/services/import-manager.ts
@@ -66,6 +66,29 @@ export interface DocumentProgress {
 }
 
 /**
+ * Record of a failed document import attempt.
+ */
+export interface FailedDocumentRecord {
+	/** Original document data */
+	document: GranolaDocument;
+
+	/** Display metadata captured at time of failure */
+	metadata?: DocumentDisplayMetadata;
+
+	/** Raw error message */
+	error: string;
+
+	/** User-friendly error description */
+	message: string;
+
+	/** Error category */
+	errorCategory?: ImportErrorCategory;
+
+	/** Timestamp of the failure */
+	timestamp: number;
+}
+
+/**
  * Overall import progress information.
  */
 export interface ImportProgress {
@@ -110,6 +133,9 @@ export interface ImportOptions {
 	/** Whether to stop on first error */
 	stopOnError: boolean;
 
+	/** Whether this import run is retrying failed documents */
+	isRetry?: boolean;
+
 	/** Custom progress callback */
 	onProgress?: (progress: ImportProgress) => void;
 
@@ -148,6 +174,9 @@ export class SelectiveImportManager {
 	private overallProgress: ImportProgress;
 	private progressCallback?: (progress: ImportProgress) => void;
 	private documentProgressCallback?: (docProgress: DocumentProgress) => void;
+	private failedDocuments: FailedDocumentRecord[] = [];
+	private lastImportMetadata: Map<string, DocumentDisplayMetadata> = new Map();
+	private lastImportOptions: ImportOptions = { ...DEFAULT_OPTIONS };
 
 	/**
 	 * Creates a new selective import manager.
@@ -193,7 +222,10 @@ export class SelectiveImportManager {
 		}
 
 		try {
-			this.startImport(selectedDocuments, options);
+			const mergedOptions: ImportOptions = { ...DEFAULT_OPTIONS, ...options };
+			this.lastImportOptions = mergedOptions;
+
+			this.startImport(selectedDocuments, mergedOptions);
 
 			// Data preparation
 			const documentMap = new Map(granolaDocuments.map(doc => [doc.id, doc]));
@@ -201,11 +233,15 @@ export class SelectiveImportManager {
 				.filter(meta => meta.selected && documentMap.has(meta.id))
 				.map(meta => ({ meta, doc: documentMap.get(meta.id)! }));
 
+			this.lastImportMetadata = new Map(
+				importQueue.map(({ meta }) => [meta.id, this.cloneMetadata(meta)])
+			);
+
 			// Update total count based on actual documents to be processed
 			this.overallProgress.total = importQueue.length;
 
 			// Document processing
-			await this.processDocumentQueue(importQueue, options);
+			await this.processDocumentQueue(importQueue, mergedOptions);
 
 			this.completeImport();
 
@@ -263,6 +299,65 @@ export class SelectiveImportManager {
 	}
 
 	/**
+	 * Gets a snapshot of failed document records from the last completed import.
+	 *
+	 * @returns {FailedDocumentRecord[]} Failed document details
+	 */
+	getFailedDocuments(): FailedDocumentRecord[] {
+		return this.failedDocuments.map(record => ({
+			...record,
+			metadata: record.metadata ? this.cloneMetadata(record.metadata) : undefined,
+			document: { ...record.document },
+		}));
+	}
+
+	/**
+	 * Retries importing the documents that previously failed.
+	 *
+	 * @param {ImportOptions} [options] - Import options for the retry attempt
+	 * @returns {Promise<ImportProgress>} Final results of the retry
+	 */
+	async retryFailedImports(options?: ImportOptions): Promise<ImportProgress> {
+		if (this.failedDocuments.length === 0) {
+			throw new Error('There are no failed documents to retry.');
+		}
+
+		const retryRecords = this.failedDocuments
+			.map(record => {
+				const metadata = record.metadata ?? this.lastImportMetadata.get(record.document.id);
+				if (!metadata) {
+					return null;
+				}
+
+				const clonedMetadata = this.cloneMetadata(metadata);
+				clonedMetadata.selected = true;
+
+				return {
+					metadata: clonedMetadata,
+					document: record.document,
+				};
+			})
+			.filter((entry): entry is { metadata: DocumentDisplayMetadata; document: GranolaDocument } =>
+				entry !== null
+			);
+
+		if (retryRecords.length === 0) {
+			throw new Error('Unable to retry failed documents because metadata is unavailable.');
+		}
+
+		const retryMetadata = retryRecords.map(entry => entry.metadata);
+		const retryDocuments = retryRecords.map(entry => entry.document);
+
+		const retryOptions: ImportOptions = {
+			...this.lastImportOptions,
+			...(options ?? {}),
+			isRetry: true,
+		};
+
+		return this.importDocuments(retryMetadata, retryDocuments, retryOptions);
+	}
+
+	/**
 	 * Resets the import manager state.
 	 * Should be called before starting a new import.
 	 */
@@ -271,6 +366,8 @@ export class SelectiveImportManager {
 		this.isCancelled = false;
 		this.documentProgress.clear();
 		this.overallProgress = this.createInitialProgress();
+		this.failedDocuments = [];
+		this.lastImportMetadata = new Map();
 	}
 
 	/**
@@ -509,17 +606,27 @@ export class SelectiveImportManager {
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 			const errorCategory = this.categorizeError(error);
+			const friendlyMessage = this.getErrorMessage(errorCategory, errorMessage);
 
 			this.updateDocumentProgress(doc.id, {
 				status: 'failed',
 				progress: 100,
-				message: this.getErrorMessage(errorCategory, errorMessage),
+				message: friendlyMessage,
 				error: errorMessage,
 				errorCategory,
 				endTime: Date.now(),
 			});
 
 			this.overallProgress.failed++;
+
+			this.failedDocuments.push({
+				document: doc,
+				metadata: this.lastImportMetadata.get(doc.id),
+				error: errorMessage,
+				message: friendlyMessage,
+				errorCategory,
+				timestamp: Date.now(),
+			});
 
 			if (options.stopOnError) {
 				this.cancel();
@@ -997,5 +1104,19 @@ export class SelectiveImportManager {
 			default:
 				return `Import failed: ${originalMessage}`;
 		}
+	}
+
+	/**
+	 * Clones document metadata to avoid accidental external mutations.
+	 *
+	 * @private
+	 * @param {DocumentDisplayMetadata} metadata - Metadata to clone
+	 * @returns {DocumentDisplayMetadata} Cloned metadata object
+	 */
+	private cloneMetadata(metadata: DocumentDisplayMetadata): DocumentDisplayMetadata {
+		return {
+			...metadata,
+			importStatus: { ...metadata.importStatus },
+		};
 	}
 }

--- a/src/services/import-manager.ts
+++ b/src/services/import-manager.ts
@@ -356,11 +356,15 @@ export class SelectiveImportManager {
 		// importDocuments calls startImport which calls reset(), clearing failedDocuments and
 		// lastImportMetadata. If import throws synchronously before any processing, we restore
 		// the snapshot so users can still export or retry the original failure set.
-		const failedSnapshot = JSON.parse(JSON.stringify(this.failedDocuments));
+		const failedSnapshot = this.failedDocuments.map(record => ({
+			...record,
+			document: this.cloneDocument(record.document),
+			metadata: record.metadata ? this.cloneMetadata(record.metadata) : undefined,
+		}));
 		const lastMetaSnapshot = new Map(
 			Array.from(this.lastImportMetadata.entries()).map(([key, value]) => [
 				key,
-				JSON.parse(JSON.stringify(value)),
+				this.cloneMetadata(value),
 			])
 		);
 

--- a/src/ui/document-selection-modal.ts
+++ b/src/ui/document-selection-modal.ts
@@ -1065,8 +1065,7 @@ export class DocumentSelectionModal extends Modal {
 				try {
 					textarea = document.createElement('textarea');
 					textarea.value = summary;
-					textarea.style.position = 'fixed';
-					textarea.style.opacity = '0';
+					textarea.className = 'granola-clipboard-fallback';
 					document.body.appendChild(textarea);
 					textarea.focus();
 					textarea.select();

--- a/src/ui/document-selection-modal.ts
+++ b/src/ui/document-selection-modal.ts
@@ -1,13 +1,13 @@
 import {
-        Modal,
-        App,
-        ButtonComponent,
-        TextComponent,
-        Notice,
-        TFile,
-        WorkspaceLeaf,
-        MarkdownView,
-        Menu,
+	Modal,
+	App,
+	ButtonComponent,
+	TextComponent,
+	Notice,
+	TFile,
+	WorkspaceLeaf,
+	MarkdownView,
+	Menu,
 } from 'obsidian';
 import { GranolaDocument, GranolaAPI } from '../api';
 import { DuplicateDetector } from '../services/duplicate-detector';
@@ -18,12 +18,12 @@ import {
 	DocumentSort,
 } from '../services/document-metadata';
 import {
-        SelectiveImportManager,
-        ImportProgress,
-        DocumentProgress,
-        DocumentImportStatus,
-        ImportOptions,
-        FailedDocumentRecord,
+	SelectiveImportManager,
+	ImportProgress,
+	DocumentProgress,
+	DocumentImportStatus,
+	ImportOptions,
+	FailedDocumentRecord,
 } from '../services/import-manager';
 import { ProseMirrorConverter } from '../converter';
 
@@ -736,21 +736,21 @@ export class DocumentSelectionModal extends Modal {
 		const summary = this.progressEl.createDiv('import-summary');
 		summary.createEl('h3', { text: 'Import complete!' });
 
-                // Get all document progress for detailed reporting
-                const allDocProgress = this.importManager.getAllDocumentProgress();
-                const failedRecords = this.importManager.getFailedDocuments();
+		// Get all document progress for detailed reporting
+		const allDocProgress = this.importManager.getAllDocumentProgress();
+		const failedRecords = this.importManager.getFailedDocuments();
 
-                // Create overview statistics
-                this.createOverviewStats(summary, result);
+		// Create overview statistics
+		this.createOverviewStats(summary, result);
 
-                // Create detailed sections for different outcomes
-                if (result.completed > 0) {
-                        this.createSuccessSection(summary, allDocProgress);
-                }
+		// Create detailed sections for different outcomes
+		if (result.completed > 0) {
+			this.createSuccessSection(summary, allDocProgress);
+		}
 
-                if (result.failed > 0) {
-                        this.createFailureSection(summary, allDocProgress);
-                }
+		if (result.failed > 0) {
+			this.createFailureSection(summary, allDocProgress);
+		}
 
 		if (result.skipped > 0) {
 			this.createSkippedSection(summary, allDocProgress);
@@ -769,43 +769,43 @@ export class DocumentSelectionModal extends Modal {
 			.map(progress => progress.file!)
 			.filter(file => file !== undefined);
 
-                // Add buttons for next actions
-                const buttonsDiv = summary.createDiv('import-complete-buttons');
+		// Add buttons for next actions
+		const buttonsDiv = summary.createDiv('import-complete-buttons');
 
-                if (failedRecords.length > 0) {
-                        new ButtonComponent(buttonsDiv)
-                                .setButtonText(`Retry failed imports (${failedRecords.length})`)
-                                .setCta()
-                                .onClick(() => {
-                                        void this.retryFailedDocuments();
-                                });
+		if (failedRecords.length > 0) {
+			new ButtonComponent(buttonsDiv)
+				.setButtonText(`Retry failed imports (${failedRecords.length})`)
+				.setCta()
+				.onClick(() => {
+					void this.retryFailedDocuments();
+				});
 
-                        new ButtonComponent(buttonsDiv)
-                                .setButtonText('Export failed list')
-                                .onClick((event: MouseEvent) => {
-                                        this.showFailedExportMenu(event);
-                                });
-                }
+			new ButtonComponent(buttonsDiv)
+				.setButtonText('Export failed list')
+				.onClick((event: MouseEvent) => {
+					this.showFailedExportMenu(event);
+				});
+		}
 
-                // If there are imported files, show "Open Imported Notes" button
-                if (importedFiles.length > 0) {
-                        const openButton = new ButtonComponent(buttonsDiv).setButtonText(
-                                `Open imported notes (${importedFiles.length})`
-                        );
+		// If there are imported files, show "Open Imported Notes" button
+		if (importedFiles.length > 0) {
+			const openButton = new ButtonComponent(buttonsDiv).setButtonText(
+				`Open imported notes (${importedFiles.length})`
+			);
 
-                        if (failedRecords.length === 0) {
-                                openButton.setCta();
-                        }
+			if (failedRecords.length === 0) {
+				openButton.setCta();
+			}
 
-                        openButton.onClick(() => {
-                                this.openImportedFiles(importedFiles);
-                                this.close();
-                        });
-                }
+			openButton.onClick(() => {
+				this.openImportedFiles(importedFiles);
+				this.close();
+			});
+		}
 
-                // Always show close button
-                new ButtonComponent(buttonsDiv).setButtonText('Close').onClick(() => this.close());
-        }
+		// Always show close button
+		new ButtonComponent(buttonsDiv).setButtonText('Close').onClick(() => this.close());
+	}
 
 	/**
 	 * Creates overview statistics section.
@@ -896,11 +896,11 @@ export class DocumentSelectionModal extends Modal {
 	 * @param {HTMLElement} container - Container element
 	 * @param {DocumentProgress[]} allDocProgress - All document progress data
 	 */
-        private createFailureSection(container: HTMLElement, allDocProgress: DocumentProgress[]): void {
-                const failedDocs = allDocProgress.filter(progress => progress.status === 'failed');
-                if (failedDocs.length === 0) return;
+	private createFailureSection(container: HTMLElement, allDocProgress: DocumentProgress[]): void {
+		const failedDocs = allDocProgress.filter(progress => progress.status === 'failed');
+		if (failedDocs.length === 0) return;
 
-                const section = container.createDiv('import-section failure-section');
+		const section = container.createDiv('import-section failure-section');
 		const header = section.createDiv('section-header');
 		header.createEl('h4', { text: `❌ Failed documents (${failedDocs.length})` });
 
@@ -936,231 +936,246 @@ export class DocumentSelectionModal extends Modal {
 			});
 		});
 
-                this.setupSectionToggle(toggle, content);
-        }
+		this.setupSectionToggle(toggle, content);
+	}
 
-        /**
-         * Retries documents that failed during the last import attempt.
-         *
-         * @private
-         * @async
-         */
-        private async retryFailedDocuments(): Promise<void> {
-                const failedRecords = this.importManager.getFailedDocuments();
-                if (failedRecords.length === 0) {
-                        new Notice('There are no failed documents to retry.');
-                        return;
-                }
+	/**
+	 * Retries documents that failed during the last import attempt.
+	 *
+	 * @private
+	 * @async
+	 */
+	private async retryFailedDocuments(): Promise<void> {
+		const failedRecords = this.importManager.getFailedDocuments();
+		if (failedRecords.length === 0) {
+			new Notice('There are no failed documents to retry.');
+			return;
+		}
 
-                // Highlight failed documents in metadata for consistency with progress view
-                const failedIds = new Set(failedRecords.map(record => record.document.id));
-                this.documentMetadata = this.documentMetadata.map(meta => ({
-                        ...meta,
-                        selected: failedIds.has(meta.id),
-                }));
+		// Highlight failed documents in metadata for consistency with progress view
+		const failedIds = new Set(failedRecords.map(record => record.document.id));
+		this.documentMetadata = this.documentMetadata.map(meta => ({
+			...meta,
+			selected: failedIds.has(meta.id),
+		}));
 
-                try {
-                        this.setImporting(true);
-                        this.showProgressView();
+		try {
+			this.setImporting(true);
+			this.showProgressView();
 
-                        const retryOptions: ImportOptions = {
-                                strategy: 'skip',
-                                stopOnError: false,
-                                onProgress: progress => this.updateProgress(progress),
-                                onDocumentProgress: docProgress => this.updateDocumentProgress(docProgress),
-                                isRetry: true,
-                        };
+			const retryOptions: ImportOptions = {
+				strategy: 'skip',
+				stopOnError: false,
+				onProgress: progress => this.updateProgress(progress),
+				onDocumentProgress: docProgress => this.updateDocumentProgress(docProgress),
+				isRetry: true,
+			};
 
-                        const result = await this.importManager.retryFailedImports(retryOptions);
-                        this.showImportComplete(result);
-                } catch (error) {
-                        console.error('[Granola Importer] Retry failed imports error:', error);
-                        const message = error instanceof Error ? error.message : 'Unknown error';
-                        new Notice(`Retry failed: ${message}`, 5000);
-                        this.showImportComplete(this.importManager.getProgress());
-                } finally {
-                        this.setImporting(false);
-                }
-        }
+			const result = await this.importManager.retryFailedImports(retryOptions);
+			this.showImportComplete(result);
+		} catch (error) {
+			console.error('[Granola Importer] Retry failed imports error:', error);
+			const message = error instanceof Error ? error.message : 'Unknown error';
+			new Notice(
+				`Retry failed: ${message}. Original failure list preserved for export.`,
+				6000
+			);
+			this.showImportComplete(this.importManager.getProgress());
+		} finally {
+			this.setImporting(false);
+		}
+	}
 
-        /**
-         * Shows export options for failed documents.
-         *
-         * @private
-         * @param {MouseEvent} event - Click event for positioning the menu
-         */
-        private showFailedExportMenu(event: MouseEvent): void {
-                const failedRecords = this.importManager.getFailedDocuments();
-                if (failedRecords.length === 0) {
-                        new Notice('There are no failed documents to export.');
-                        return;
-                }
+	/**
+	 * Shows export options for failed documents.
+	 *
+	 * @private
+	 * @param {MouseEvent} event - Click event for positioning the menu
+	 */
+	private showFailedExportMenu(event: MouseEvent): void {
+		const failedRecords = this.importManager.getFailedDocuments();
+		if (failedRecords.length === 0) {
+			new Notice('There are no failed documents to export.');
+			return;
+		}
 
-                const menu = new Menu();
-                menu.addItem(item =>
-                        item.setTitle('Download CSV').onClick(() => {
-                                this.exportFailedDocumentsAsCSV(failedRecords);
-                        })
-                );
+		const menu = new Menu();
+		menu.addItem(item =>
+			item.setTitle('Download CSV').onClick(() => {
+				this.exportFailedDocumentsAsCSV(failedRecords);
+			})
+		);
 
-                menu.addItem(item =>
-                        item.setTitle('Copy summary to clipboard').onClick(() => {
-                                void this.copyFailedDocumentsToClipboard(failedRecords);
-                        })
-                );
+		menu.addItem(item =>
+			item.setTitle('Copy summary to clipboard').onClick(() => {
+				void this.copyFailedDocumentsToClipboard(failedRecords);
+			})
+		);
 
-                menu.showAtMouseEvent(event);
-        }
+		menu.showAtMouseEvent(event);
+	}
 
-        /**
-         * Exports failed document details as a CSV file for troubleshooting.
-         *
-         * @private
-         * @param {FailedDocumentRecord[]} records - Failed document records
-         */
-        private exportFailedDocumentsAsCSV(records: FailedDocumentRecord[]): void {
-                if (records.length === 0) {
-                        new Notice('There are no failed documents to export.');
-                        return;
-                }
+	/**
+	 * Exports failed document details as a CSV file for troubleshooting.
+	 *
+	 * @private
+	 * @param {FailedDocumentRecord[]} records - Failed document records
+	 */
+	private exportFailedDocumentsAsCSV(records: FailedDocumentRecord[]): void {
+		if (records.length === 0) {
+			new Notice('There are no failed documents to export.');
+			return;
+		}
 
-                const csvContent = this.buildFailedDocumentsCsv(records);
-                const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-                const url = URL.createObjectURL(blob);
-                const link = document.createElement('a');
-                link.href = url;
-                link.download = `granola-failed-imports-${new Date().toISOString()}.csv`;
-                document.body.appendChild(link);
-                link.click();
-                document.body.removeChild(link);
-                URL.revokeObjectURL(url);
+		const csvContent = this.buildFailedDocumentsCsv(records);
+		const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+		const url = URL.createObjectURL(blob);
+		const link = document.createElement('a');
+		link.href = url;
+		link.download = `granola-failed-imports-${new Date().toISOString().replace(/:/g, '-')}.csv`;
+		document.body.appendChild(link);
+		link.click();
+		document.body.removeChild(link);
+		URL.revokeObjectURL(url);
 
-                new Notice('Failed import list exported as CSV.');
-        }
+		new Notice('Failed import list exported as CSV.');
+	}
 
-        /**
-         * Copies a formatted summary of failed documents to the clipboard.
-         *
-         * @private
-         * @param {FailedDocumentRecord[]} records - Failed document records
-         */
-        private async copyFailedDocumentsToClipboard(records: FailedDocumentRecord[]): Promise<void> {
-                if (records.length === 0) {
-                        new Notice('There are no failed documents to copy.');
-                        return;
-                }
+	/**
+	 * Copies a formatted summary of failed documents to the clipboard.
+	 *
+	 * @private
+	 * @param {FailedDocumentRecord[]} records - Failed document records
+	 */
+	private async copyFailedDocumentsToClipboard(records: FailedDocumentRecord[]): Promise<void> {
+		if (records.length === 0) {
+			new Notice('There are no failed documents to copy.');
+			return;
+		}
 
-                const summary = this.buildFailedDocumentsSummary(records);
+		const summary = this.buildFailedDocumentsSummary(records);
 
-                try {
-                        if (navigator?.clipboard?.writeText) {
-                                await navigator.clipboard.writeText(summary);
-                        } else {
-                                const textarea = document.createElement('textarea');
-                                textarea.value = summary;
-                                textarea.style.position = 'fixed';
-                                textarea.style.opacity = '0';
-                                document.body.appendChild(textarea);
-                                textarea.focus();
-                                textarea.select();
-                                document.execCommand('copy');
-                                document.body.removeChild(textarea);
-                        }
+		try {
+			// Try modern Clipboard API first
+			if (navigator?.clipboard?.writeText) {
+				await navigator.clipboard.writeText(summary);
+			} else {
+				// Fallback to deprecated execCommand for older browsers
+				let textarea: HTMLTextAreaElement | null = null;
+				try {
+					textarea = document.createElement('textarea');
+					textarea.value = summary;
+					textarea.style.position = 'fixed';
+					textarea.style.opacity = '0';
+					document.body.appendChild(textarea);
+					textarea.focus();
+					textarea.select();
 
-                        new Notice('Failed import summary copied to clipboard.');
-                } catch (error) {
-                        console.error('[Granola Importer] Clipboard copy failed:', error);
-                        new Notice('Unable to copy failed import summary to clipboard.', 5000);
-                }
-        }
+					const successful = document.execCommand('copy');
+					if (!successful) {
+						throw new Error('document.execCommand("copy") failed');
+					}
+				} finally {
+					if (textarea && document.body.contains(textarea)) {
+						document.body.removeChild(textarea);
+					}
+				}
+			}
 
-        /**
-         * Builds CSV content for failed document records.
-         *
-         * @private
-         * @param {FailedDocumentRecord[]} records - Failed document records
-         * @returns {string} CSV formatted string
-         */
-        private buildFailedDocumentsCsv(records: FailedDocumentRecord[]): string {
-                const header = '"Document ID","Title","Error Reason","Failed At"';
-                const rows = records.map(record => {
-                        const id = this.csvEscape(record.document.id);
-                        const title = this.csvEscape(this.getFailedDocumentTitle(record));
-                        const reason = this.csvEscape(record.message || record.error || 'Unknown error');
-                        const failedAt = this.csvEscape(this.formatFailureTimestamp(record.timestamp));
-                        return `"${id}","${title}","${reason}","${failedAt}"`;
-                });
+			new Notice('Failed import summary copied to clipboard.');
+		} catch (error) {
+			console.error('[Granola Importer] Clipboard copy failed:', error);
+			new Notice('Unable to copy failed import summary to clipboard.', 5000);
+		}
+	}
 
-                return [header, ...rows].join('\n');
-        }
+	/**
+	 * Builds CSV content for failed document records.
+	 *
+	 * @private
+	 * @param {FailedDocumentRecord[]} records - Failed document records
+	 * @returns {string} CSV formatted string
+	 */
+	private buildFailedDocumentsCsv(records: FailedDocumentRecord[]): string {
+		const header = '"Document ID","Title","Error Reason","Failed At"';
+		const rows = records.map(record => {
+			const id = this.csvEscape(record.document.id);
+			const title = this.csvEscape(this.getFailedDocumentTitle(record));
+			const reason = this.csvEscape(record.message || record.error || 'Unknown error');
+			const failedAt = this.csvEscape(this.formatFailureTimestamp(record.timestamp));
+			return `"${id}","${title}","${reason}","${failedAt}"`;
+		});
 
-        /**
-         * Builds a troubleshooting-friendly summary for failed documents.
-         *
-         * @private
-         * @param {FailedDocumentRecord[]} records - Failed document records
-         * @returns {string} Summary text for clipboard export
-         */
-        private buildFailedDocumentsSummary(records: FailedDocumentRecord[]): string {
-                const lines: string[] = [];
-                lines.push('Granola Failed Import Summary');
-                lines.push(`Generated: ${new Date().toISOString()}`);
-                lines.push(`Total failed documents: ${records.length}`);
-                lines.push('');
+		return [header, ...rows].join('\n');
+	}
 
-                records.forEach(record => {
-                        const title = this.getFailedDocumentTitle(record);
-                        const reason = record.message || record.error || 'Unknown error';
-                        const failedAt = this.formatFailureTimestamp(record.timestamp);
-                        lines.push(`• ${title}`);
-                        lines.push(`  ID: ${record.document.id}`);
-                        lines.push(`  Reason: ${reason}`);
-                        lines.push(`  Failed at: ${failedAt}`);
-                        lines.push('');
-                });
+	/**
+	 * Builds a troubleshooting-friendly summary for failed documents.
+	 *
+	 * @private
+	 * @param {FailedDocumentRecord[]} records - Failed document records
+	 * @returns {string} Summary text for clipboard export
+	 */
+	private buildFailedDocumentsSummary(records: FailedDocumentRecord[]): string {
+		const lines: string[] = [];
+		lines.push('Granola Failed Import Summary');
+		lines.push(`Generated: ${new Date().toISOString()}`);
+		lines.push(`Total failed documents: ${records.length}`);
+		lines.push('');
 
-                return lines.join('\n');
-        }
+		records.forEach(record => {
+			const title = this.getFailedDocumentTitle(record);
+			const reason = record.message || record.error || 'Unknown error';
+			const failedAt = this.formatFailureTimestamp(record.timestamp);
+			lines.push(`• ${title}`);
+			lines.push(`  ID: ${record.document.id}`);
+			lines.push(`  Reason: ${reason}`);
+			lines.push(`  Failed at: ${failedAt}`);
+			lines.push('');
+		});
 
-        /**
-         * Escapes values for safe inclusion in CSV content.
-         *
-         * @private
-         * @param {string} value - Value to escape
-         * @returns {string} Escaped value
-         */
-        private csvEscape(value: string): string {
-                return value.replace(/"/g, '""');
-        }
+		return lines.join('\n');
+	}
 
-        /**
-         * Gets a user-friendly title for a failed document record.
-         *
-         * @private
-         * @param {FailedDocumentRecord} record - Failed document record
-         * @returns {string} Document title
-         */
-        private getFailedDocumentTitle(record: FailedDocumentRecord): string {
-                return record.metadata?.title || record.document.title || 'Unknown Document';
-        }
+	/**
+	 * Escapes values for safe inclusion in CSV content.
+	 *
+	 * @private
+	 * @param {string} value - Value to escape
+	 * @returns {string} Escaped value
+	 */
+	private csvEscape(value: string): string {
+		return value.replace(/"/g, '""');
+	}
 
-        /**
-         * Formats the failure timestamp consistently.
-         *
-         * @private
-         * @param {number} timestamp - Failure timestamp (ms since epoch)
-         * @returns {string} ISO formatted timestamp or placeholder
-         */
-        private formatFailureTimestamp(timestamp: number): string {
-                if (!Number.isFinite(timestamp)) {
-                        return 'Unknown';
-                }
-                try {
-                        return new Date(timestamp).toISOString();
-                } catch (error) {
-                        return 'Unknown';
-                }
-        }
+	/**
+	 * Gets a user-friendly title for a failed document record.
+	 *
+	 * @private
+	 * @param {FailedDocumentRecord} record - Failed document record
+	 * @returns {string} Document title
+	 */
+	private getFailedDocumentTitle(record: FailedDocumentRecord): string {
+		return record.metadata?.title || record.document.title || 'Unknown Document';
+	}
+
+	/**
+	 * Formats the failure timestamp consistently.
+	 *
+	 * @private
+	 * @param {number} timestamp - Failure timestamp (ms since epoch)
+	 * @returns {string} ISO formatted timestamp or placeholder
+	 */
+	private formatFailureTimestamp(timestamp: number): string {
+		if (!Number.isFinite(timestamp)) {
+			return 'Unknown';
+		}
+		try {
+			return new Date(timestamp).toISOString();
+		} catch (error) {
+			return 'Unknown';
+		}
+	}
 
 	/**
 	 * Creates skipped section with categorized reasons.

--- a/src/ui/document-selection-modal.ts
+++ b/src/ui/document-selection-modal.ts
@@ -1,12 +1,13 @@
 import {
-	Modal,
-	App,
-	ButtonComponent,
-	TextComponent,
-	Notice,
-	TFile,
-	WorkspaceLeaf,
-	MarkdownView,
+        Modal,
+        App,
+        ButtonComponent,
+        TextComponent,
+        Notice,
+        TFile,
+        WorkspaceLeaf,
+        MarkdownView,
+        Menu,
 } from 'obsidian';
 import { GranolaDocument, GranolaAPI } from '../api';
 import { DuplicateDetector } from '../services/duplicate-detector';
@@ -17,11 +18,12 @@ import {
 	DocumentSort,
 } from '../services/document-metadata';
 import {
-	SelectiveImportManager,
-	ImportProgress,
-	DocumentProgress,
-	DocumentImportStatus,
-	ImportOptions,
+        SelectiveImportManager,
+        ImportProgress,
+        DocumentProgress,
+        DocumentImportStatus,
+        ImportOptions,
+        FailedDocumentRecord,
 } from '../services/import-manager';
 import { ProseMirrorConverter } from '../converter';
 
@@ -734,20 +736,21 @@ export class DocumentSelectionModal extends Modal {
 		const summary = this.progressEl.createDiv('import-summary');
 		summary.createEl('h3', { text: 'Import complete!' });
 
-		// Get all document progress for detailed reporting
-		const allDocProgress = this.importManager.getAllDocumentProgress();
+                // Get all document progress for detailed reporting
+                const allDocProgress = this.importManager.getAllDocumentProgress();
+                const failedRecords = this.importManager.getFailedDocuments();
 
-		// Create overview statistics
-		this.createOverviewStats(summary, result);
+                // Create overview statistics
+                this.createOverviewStats(summary, result);
 
-		// Create detailed sections for different outcomes
-		if (result.completed > 0) {
-			this.createSuccessSection(summary, allDocProgress);
-		}
+                // Create detailed sections for different outcomes
+                if (result.completed > 0) {
+                        this.createSuccessSection(summary, allDocProgress);
+                }
 
-		if (result.failed > 0) {
-			this.createFailureSection(summary, allDocProgress);
-		}
+                if (result.failed > 0) {
+                        this.createFailureSection(summary, allDocProgress);
+                }
 
 		if (result.skipped > 0) {
 			this.createSkippedSection(summary, allDocProgress);
@@ -766,23 +769,43 @@ export class DocumentSelectionModal extends Modal {
 			.map(progress => progress.file!)
 			.filter(file => file !== undefined);
 
-		// Add buttons for next actions
-		const buttonsDiv = summary.createDiv('import-complete-buttons');
+                // Add buttons for next actions
+                const buttonsDiv = summary.createDiv('import-complete-buttons');
 
-		// If there are imported files, show "Open Imported Notes" button
-		if (importedFiles.length > 0) {
-			new ButtonComponent(buttonsDiv)
-				.setButtonText(`Open imported notes (${importedFiles.length})`)
-				.setCta()
-				.onClick(() => {
-					this.openImportedFiles(importedFiles);
-					this.close();
-				});
-		}
+                if (failedRecords.length > 0) {
+                        new ButtonComponent(buttonsDiv)
+                                .setButtonText(`Retry failed imports (${failedRecords.length})`)
+                                .setCta()
+                                .onClick(() => {
+                                        void this.retryFailedDocuments();
+                                });
 
-		// Always show close button
-		new ButtonComponent(buttonsDiv).setButtonText('Close').onClick(() => this.close());
-	}
+                        new ButtonComponent(buttonsDiv)
+                                .setButtonText('Export failed list')
+                                .onClick((event: MouseEvent) => {
+                                        this.showFailedExportMenu(event);
+                                });
+                }
+
+                // If there are imported files, show "Open Imported Notes" button
+                if (importedFiles.length > 0) {
+                        const openButton = new ButtonComponent(buttonsDiv).setButtonText(
+                                `Open imported notes (${importedFiles.length})`
+                        );
+
+                        if (failedRecords.length === 0) {
+                                openButton.setCta();
+                        }
+
+                        openButton.onClick(() => {
+                                this.openImportedFiles(importedFiles);
+                                this.close();
+                        });
+                }
+
+                // Always show close button
+                new ButtonComponent(buttonsDiv).setButtonText('Close').onClick(() => this.close());
+        }
 
 	/**
 	 * Creates overview statistics section.
@@ -873,11 +896,11 @@ export class DocumentSelectionModal extends Modal {
 	 * @param {HTMLElement} container - Container element
 	 * @param {DocumentProgress[]} allDocProgress - All document progress data
 	 */
-	private createFailureSection(container: HTMLElement, allDocProgress: DocumentProgress[]): void {
-		const failedDocs = allDocProgress.filter(progress => progress.status === 'failed');
-		if (failedDocs.length === 0) return;
+        private createFailureSection(container: HTMLElement, allDocProgress: DocumentProgress[]): void {
+                const failedDocs = allDocProgress.filter(progress => progress.status === 'failed');
+                if (failedDocs.length === 0) return;
 
-		const section = container.createDiv('import-section failure-section');
+                const section = container.createDiv('import-section failure-section');
 		const header = section.createDiv('section-header');
 		header.createEl('h4', { text: `❌ Failed documents (${failedDocs.length})` });
 
@@ -913,8 +936,231 @@ export class DocumentSelectionModal extends Modal {
 			});
 		});
 
-		this.setupSectionToggle(toggle, content);
-	}
+                this.setupSectionToggle(toggle, content);
+        }
+
+        /**
+         * Retries documents that failed during the last import attempt.
+         *
+         * @private
+         * @async
+         */
+        private async retryFailedDocuments(): Promise<void> {
+                const failedRecords = this.importManager.getFailedDocuments();
+                if (failedRecords.length === 0) {
+                        new Notice('There are no failed documents to retry.');
+                        return;
+                }
+
+                // Highlight failed documents in metadata for consistency with progress view
+                const failedIds = new Set(failedRecords.map(record => record.document.id));
+                this.documentMetadata = this.documentMetadata.map(meta => ({
+                        ...meta,
+                        selected: failedIds.has(meta.id),
+                }));
+
+                try {
+                        this.setImporting(true);
+                        this.showProgressView();
+
+                        const retryOptions: ImportOptions = {
+                                strategy: 'skip',
+                                stopOnError: false,
+                                onProgress: progress => this.updateProgress(progress),
+                                onDocumentProgress: docProgress => this.updateDocumentProgress(docProgress),
+                                isRetry: true,
+                        };
+
+                        const result = await this.importManager.retryFailedImports(retryOptions);
+                        this.showImportComplete(result);
+                } catch (error) {
+                        console.error('[Granola Importer] Retry failed imports error:', error);
+                        const message = error instanceof Error ? error.message : 'Unknown error';
+                        new Notice(`Retry failed: ${message}`, 5000);
+                        this.showImportComplete(this.importManager.getProgress());
+                } finally {
+                        this.setImporting(false);
+                }
+        }
+
+        /**
+         * Shows export options for failed documents.
+         *
+         * @private
+         * @param {MouseEvent} event - Click event for positioning the menu
+         */
+        private showFailedExportMenu(event: MouseEvent): void {
+                const failedRecords = this.importManager.getFailedDocuments();
+                if (failedRecords.length === 0) {
+                        new Notice('There are no failed documents to export.');
+                        return;
+                }
+
+                const menu = new Menu();
+                menu.addItem(item =>
+                        item.setTitle('Download CSV').onClick(() => {
+                                this.exportFailedDocumentsAsCSV(failedRecords);
+                        })
+                );
+
+                menu.addItem(item =>
+                        item.setTitle('Copy summary to clipboard').onClick(() => {
+                                void this.copyFailedDocumentsToClipboard(failedRecords);
+                        })
+                );
+
+                menu.showAtMouseEvent(event);
+        }
+
+        /**
+         * Exports failed document details as a CSV file for troubleshooting.
+         *
+         * @private
+         * @param {FailedDocumentRecord[]} records - Failed document records
+         */
+        private exportFailedDocumentsAsCSV(records: FailedDocumentRecord[]): void {
+                if (records.length === 0) {
+                        new Notice('There are no failed documents to export.');
+                        return;
+                }
+
+                const csvContent = this.buildFailedDocumentsCsv(records);
+                const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+                const url = URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                link.href = url;
+                link.download = `granola-failed-imports-${new Date().toISOString()}.csv`;
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                URL.revokeObjectURL(url);
+
+                new Notice('Failed import list exported as CSV.');
+        }
+
+        /**
+         * Copies a formatted summary of failed documents to the clipboard.
+         *
+         * @private
+         * @param {FailedDocumentRecord[]} records - Failed document records
+         */
+        private async copyFailedDocumentsToClipboard(records: FailedDocumentRecord[]): Promise<void> {
+                if (records.length === 0) {
+                        new Notice('There are no failed documents to copy.');
+                        return;
+                }
+
+                const summary = this.buildFailedDocumentsSummary(records);
+
+                try {
+                        if (navigator?.clipboard?.writeText) {
+                                await navigator.clipboard.writeText(summary);
+                        } else {
+                                const textarea = document.createElement('textarea');
+                                textarea.value = summary;
+                                textarea.style.position = 'fixed';
+                                textarea.style.opacity = '0';
+                                document.body.appendChild(textarea);
+                                textarea.focus();
+                                textarea.select();
+                                document.execCommand('copy');
+                                document.body.removeChild(textarea);
+                        }
+
+                        new Notice('Failed import summary copied to clipboard.');
+                } catch (error) {
+                        console.error('[Granola Importer] Clipboard copy failed:', error);
+                        new Notice('Unable to copy failed import summary to clipboard.', 5000);
+                }
+        }
+
+        /**
+         * Builds CSV content for failed document records.
+         *
+         * @private
+         * @param {FailedDocumentRecord[]} records - Failed document records
+         * @returns {string} CSV formatted string
+         */
+        private buildFailedDocumentsCsv(records: FailedDocumentRecord[]): string {
+                const header = '"Document ID","Title","Error Reason","Failed At"';
+                const rows = records.map(record => {
+                        const id = this.csvEscape(record.document.id);
+                        const title = this.csvEscape(this.getFailedDocumentTitle(record));
+                        const reason = this.csvEscape(record.message || record.error || 'Unknown error');
+                        const failedAt = this.csvEscape(this.formatFailureTimestamp(record.timestamp));
+                        return `"${id}","${title}","${reason}","${failedAt}"`;
+                });
+
+                return [header, ...rows].join('\n');
+        }
+
+        /**
+         * Builds a troubleshooting-friendly summary for failed documents.
+         *
+         * @private
+         * @param {FailedDocumentRecord[]} records - Failed document records
+         * @returns {string} Summary text for clipboard export
+         */
+        private buildFailedDocumentsSummary(records: FailedDocumentRecord[]): string {
+                const lines: string[] = [];
+                lines.push('Granola Failed Import Summary');
+                lines.push(`Generated: ${new Date().toISOString()}`);
+                lines.push(`Total failed documents: ${records.length}`);
+                lines.push('');
+
+                records.forEach(record => {
+                        const title = this.getFailedDocumentTitle(record);
+                        const reason = record.message || record.error || 'Unknown error';
+                        const failedAt = this.formatFailureTimestamp(record.timestamp);
+                        lines.push(`• ${title}`);
+                        lines.push(`  ID: ${record.document.id}`);
+                        lines.push(`  Reason: ${reason}`);
+                        lines.push(`  Failed at: ${failedAt}`);
+                        lines.push('');
+                });
+
+                return lines.join('\n');
+        }
+
+        /**
+         * Escapes values for safe inclusion in CSV content.
+         *
+         * @private
+         * @param {string} value - Value to escape
+         * @returns {string} Escaped value
+         */
+        private csvEscape(value: string): string {
+                return value.replace(/"/g, '""');
+        }
+
+        /**
+         * Gets a user-friendly title for a failed document record.
+         *
+         * @private
+         * @param {FailedDocumentRecord} record - Failed document record
+         * @returns {string} Document title
+         */
+        private getFailedDocumentTitle(record: FailedDocumentRecord): string {
+                return record.metadata?.title || record.document.title || 'Unknown Document';
+        }
+
+        /**
+         * Formats the failure timestamp consistently.
+         *
+         * @private
+         * @param {number} timestamp - Failure timestamp (ms since epoch)
+         * @returns {string} ISO formatted timestamp or placeholder
+         */
+        private formatFailureTimestamp(timestamp: number): string {
+                if (!Number.isFinite(timestamp)) {
+                        return 'Unknown';
+                }
+                try {
+                        return new Date(timestamp).toISOString();
+                } catch (error) {
+                        return 'Unknown';
+                }
+        }
 
 	/**
 	 * Creates skipped section with categorized reasons.

--- a/styles.css
+++ b/styles.css
@@ -743,3 +743,10 @@
 .granola-import-modal .empty-doc-title {
 	font-weight: 500;
 }
+
+/* Clipboard fallback textarea */
+.granola-clipboard-fallback {
+	position: fixed;
+	opacity: 0;
+	pointer-events: none;
+}

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -36,9 +36,25 @@ export function stringifyYaml(obj: any): string {
 	return lines.join('\n');
 }
 
-// Mock htmlToMarkdown function
+// Mock htmlToMarkdown function - converts HTML to plain text for testing
 export function htmlToMarkdown(html: string): string {
-	return html;
+	if (!html || typeof html !== 'string') {
+		return '';
+	}
+
+	// Basic HTML to text conversion for testing
+	// Remove HTML tags and decode entities
+	return html
+		.replace(/<[^>]*>/g, ' ') // Remove all HTML tags
+		.replace(/&nbsp;/g, ' ') // Replace non-breaking spaces
+		.replace(/&amp;/g, '&') // Handle common HTML entities
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&apos;/g, "'")
+		.replace(/\s+/g, ' ') // Normalize whitespace
+		.trim();
 }
 
 // Mock Platform object

--- a/tests/helpers/ui-mocks.ts
+++ b/tests/helpers/ui-mocks.ts
@@ -137,7 +137,7 @@ export function createMockModal(): any {
 	return {
 		containerEl: {
 			createEl: jest.fn().mockImplementation((tag, attrs) => ({
-				innerHTML: '',
+				textContent: '',
 				createEl: jest.fn().mockReturnThis(),
 				createDiv: jest.fn().mockReturnThis(),
 				addClass: jest.fn().mockReturnThis(),

--- a/tests/unit/document-selection-modal.test.ts
+++ b/tests/unit/document-selection-modal.test.ts
@@ -38,13 +38,13 @@ const mockMetadataService = {
 } as unknown as DocumentMetadataService;
 
 const mockImportManager = {
-        importDocuments: jest.fn(),
-        cancel: jest.fn(),
-        reset: jest.fn(),
-        getProgress: jest.fn(),
-        getAllDocumentProgress: jest.fn().mockReturnValue([]),
-        getFailedDocuments: jest.fn().mockReturnValue([]),
-        retryFailedImports: jest.fn(),
+	importDocuments: jest.fn(),
+	cancel: jest.fn(),
+	reset: jest.fn(),
+	getProgress: jest.fn(),
+	getAllDocumentProgress: jest.fn().mockReturnValue([]),
+	getFailedDocuments: jest.fn().mockReturnValue([]),
+	retryFailedImports: jest.fn(),
 } as unknown as SelectiveImportManager;
 
 const mockConverter = {
@@ -69,11 +69,11 @@ const mockElement = {
 
 // Mock Modal class
 jest.mock('obsidian', () => ({
-        Modal: class MockModal {
-                app: App;
-                contentEl: any;
-                titleEl: any;
-                modalEl: any;
+	Modal: class MockModal {
+		app: App;
+		contentEl: any;
+		titleEl: any;
+		modalEl: any;
 
 		constructor(app: App) {
 			this.app = app;
@@ -88,11 +88,11 @@ jest.mock('obsidian', () => ({
 
 		close() {
 			return this;
-                }
-        },
-        ButtonComponent: class MockButtonComponent {
-                constructor(public container: any) {}
-                setButtonText(text: string) {
+		}
+	},
+	ButtonComponent: class MockButtonComponent {
+		constructor(public container: any) {}
+		setButtonText(text: string) {
 			return this;
 		}
 		setCta() {
@@ -119,19 +119,19 @@ jest.mock('obsidian', () => ({
 		onChange(callback: (value: string) => void) {
 			return this;
 		}
-        },
-        Notice: jest.fn(),
-        Menu: class MockMenu {
-                addItem(callback: (item: any) => void) {
-                        const item = {
-                                setTitle: jest.fn().mockReturnThis(),
-                                onClick: jest.fn().mockReturnThis(),
-                        };
-                        callback(item);
-                        return this;
-                }
-                showAtMouseEvent = jest.fn();
-        },
+	},
+	Notice: jest.fn(),
+	Menu: class MockMenu {
+		addItem(callback: (item: any) => void) {
+			const item = {
+				setTitle: jest.fn().mockReturnThis(),
+				onClick: jest.fn().mockReturnThis(),
+			};
+			callback(item);
+			return this;
+		}
+		showAtMouseEvent = jest.fn();
+	},
 }));
 
 describe('DocumentSelectionModal', () => {

--- a/tests/unit/document-selection-modal.test.ts
+++ b/tests/unit/document-selection-modal.test.ts
@@ -38,10 +38,13 @@ const mockMetadataService = {
 } as unknown as DocumentMetadataService;
 
 const mockImportManager = {
-	importDocuments: jest.fn(),
-	cancel: jest.fn(),
-	reset: jest.fn(),
-	getProgress: jest.fn(),
+        importDocuments: jest.fn(),
+        cancel: jest.fn(),
+        reset: jest.fn(),
+        getProgress: jest.fn(),
+        getAllDocumentProgress: jest.fn().mockReturnValue([]),
+        getFailedDocuments: jest.fn().mockReturnValue([]),
+        retryFailedImports: jest.fn(),
 } as unknown as SelectiveImportManager;
 
 const mockConverter = {
@@ -66,11 +69,11 @@ const mockElement = {
 
 // Mock Modal class
 jest.mock('obsidian', () => ({
-	Modal: class MockModal {
-		app: App;
-		contentEl: any;
-		titleEl: any;
-		modalEl: any;
+        Modal: class MockModal {
+                app: App;
+                contentEl: any;
+                titleEl: any;
+                modalEl: any;
 
 		constructor(app: App) {
 			this.app = app;
@@ -85,11 +88,11 @@ jest.mock('obsidian', () => ({
 
 		close() {
 			return this;
-		}
-	},
-	ButtonComponent: class MockButtonComponent {
-		constructor(public container: any) {}
-		setButtonText(text: string) {
+                }
+        },
+        ButtonComponent: class MockButtonComponent {
+                constructor(public container: any) {}
+                setButtonText(text: string) {
 			return this;
 		}
 		setCta() {
@@ -116,8 +119,19 @@ jest.mock('obsidian', () => ({
 		onChange(callback: (value: string) => void) {
 			return this;
 		}
-	},
-	Notice: jest.fn(),
+        },
+        Notice: jest.fn(),
+        Menu: class MockMenu {
+                addItem(callback: (item: any) => void) {
+                        const item = {
+                                setTitle: jest.fn().mockReturnThis(),
+                                onClick: jest.fn().mockReturnThis(),
+                        };
+                        callback(item);
+                        return this;
+                }
+                showAtMouseEvent = jest.fn();
+        },
 }));
 
 describe('DocumentSelectionModal', () => {

--- a/tests/unit/document-selection-modal.test.ts
+++ b/tests/unit/document-selection-modal.test.ts
@@ -61,7 +61,6 @@ const mockElement = {
 	appendChild: jest.fn(),
 	removeChild: jest.fn(),
 	style: {},
-	innerHTML: '',
 	textContent: '',
 	addEventListener: jest.fn(),
 	removeEventListener: jest.fn(),

--- a/tests/unit/import-manager.test.ts
+++ b/tests/unit/import-manager.test.ts
@@ -578,8 +578,8 @@ describe('SelectiveImportManager', () => {
 
 	// Removed backup creation tests as createBackups option was removed
 
-        describe('edge cases and error recovery', () => {
-                it('should handle errors in handleImportError method', async () => {
+	describe('edge cases and error recovery', () => {
+		it('should handle errors in handleImportError method', async () => {
 			// Mock conversion to throw an error to trigger handleImportError
 			(mockConverter.convertDocument as jest.Mock).mockImplementationOnce(() => {
 				throw new Error('Critical conversion error');
@@ -864,98 +864,98 @@ describe('SelectiveImportManager', () => {
 			// The document should either be completed (if conflict resolution succeeds) or skipped
 			expect(result.completed + result.skipped).toBe(1);
 			expect(result.failed).toBe(0);
-                });
-        });
+		});
+	});
 
-        describe('failed import recovery features', () => {
-                it('tracks failed documents with metadata and error details', async () => {
-                        (mockConverter.convertDocument as jest.Mock).mockImplementation(doc => {
-                                if (doc.id === 'doc1') {
-                                        throw new Error('Conversion failed for doc1');
-                                }
+	describe('failed import recovery features', () => {
+		it('tracks failed documents with metadata and error details', async () => {
+			(mockConverter.convertDocument as jest.Mock).mockImplementation(doc => {
+				if (doc.id === 'doc1') {
+					throw new Error('Conversion failed for doc1');
+				}
 
-                                return {
-                                        filename: `${doc.id}.md`,
-                                        content: '# Markdown content',
-                                        frontmatter: { granola_id: doc.id, title: doc.title },
-                                        isTrulyEmpty: false,
-                                };
-                        });
+				return {
+					filename: `${doc.id}.md`,
+					content: '# Markdown content',
+					frontmatter: { granola_id: doc.id, title: doc.title },
+					isTrulyEmpty: false,
+				};
+			});
 
-                        await importManager.importDocuments(mockDocumentMetadata, mockGranolaDocuments, {
-                                ...defaultOptions,
-                                stopOnError: false,
-                        });
+			await importManager.importDocuments(mockDocumentMetadata, mockGranolaDocuments, {
+				...defaultOptions,
+				stopOnError: false,
+			});
 
-                        const failedRecords = importManager.getFailedDocuments();
-                        expect(failedRecords).toHaveLength(1);
-                        const failedRecord = failedRecords[0];
-                        expect(failedRecord.document.id).toBe('doc1');
-                        expect(failedRecord.metadata?.id).toBe('doc1');
-                        expect(failedRecord.metadata?.title).toBe('Document 1');
-                        expect(failedRecord.error).toContain('Conversion failed');
-                        expect(failedRecord.message).toContain('failed');
-                        expect(typeof failedRecord.timestamp).toBe('number');
-                });
+			const failedRecords = importManager.getFailedDocuments();
+			expect(failedRecords).toHaveLength(1);
+			const failedRecord = failedRecords[0];
+			expect(failedRecord.document.id).toBe('doc1');
+			expect(failedRecord.metadata?.id).toBe('doc1');
+			expect(failedRecord.metadata?.title).toBe('Document 1');
+			expect(failedRecord.error).toContain('Conversion failed');
+			expect(failedRecord.message).toContain('failed');
+			expect(typeof failedRecord.timestamp).toBe('number');
+		});
 
-                it('retries only failed documents using stored context', async () => {
-                        let shouldFailDoc1 = true;
-                        (mockConverter.convertDocument as jest.Mock).mockImplementation(doc => {
-                                if (doc.id === 'doc1' && shouldFailDoc1) {
-                                        shouldFailDoc1 = false;
-                                        throw new Error('Initial failure for doc1');
-                                }
+		it('retries only failed documents using stored context', async () => {
+			let shouldFailDoc1 = true;
+			(mockConverter.convertDocument as jest.Mock).mockImplementation(doc => {
+				if (doc.id === 'doc1' && shouldFailDoc1) {
+					shouldFailDoc1 = false;
+					throw new Error('Initial failure for doc1');
+				}
 
-                                return {
-                                        filename: `${doc.id}.md`,
-                                        content: '# Markdown content',
-                                        frontmatter: { granola_id: doc.id, title: doc.title },
-                                        isTrulyEmpty: false,
-                                };
-                        });
+				return {
+					filename: `${doc.id}.md`,
+					content: '# Markdown content',
+					frontmatter: { granola_id: doc.id, title: doc.title },
+					isTrulyEmpty: false,
+				};
+			});
 
-                        await importManager.importDocuments(mockDocumentMetadata, mockGranolaDocuments, {
-                                ...defaultOptions,
-                                stopOnError: false,
-                        });
+			await importManager.importDocuments(mockDocumentMetadata, mockGranolaDocuments, {
+				...defaultOptions,
+				stopOnError: false,
+			});
 
-                        const failedRecords = importManager.getFailedDocuments();
-                        expect(failedRecords).toHaveLength(1);
-                        const initialCreateCalls = (mockVault.create as jest.Mock).mock.calls.length;
+			const failedRecords = importManager.getFailedDocuments();
+			expect(failedRecords).toHaveLength(1);
+			const initialCreateCalls = (mockVault.create as jest.Mock).mock.calls.length;
 
-                        const retryProgressUpdates: ImportProgress[] = [];
-                        const retryDocumentUpdates: DocumentProgress[] = [];
+			const retryProgressUpdates: ImportProgress[] = [];
+			const retryDocumentUpdates: DocumentProgress[] = [];
 
-                        const retryResult = await importManager.retryFailedImports({
-                                ...defaultOptions,
-                                onProgress: progress => retryProgressUpdates.push(progress),
-                                onDocumentProgress: docProgress => retryDocumentUpdates.push(docProgress),
-                        });
+			const retryResult = await importManager.retryFailedImports({
+				...defaultOptions,
+				onProgress: progress => retryProgressUpdates.push(progress),
+				onDocumentProgress: docProgress => retryDocumentUpdates.push(docProgress),
+			});
 
-                        expect(retryResult.total).toBe(1);
-                        expect(retryResult.failed).toBe(0);
-                        expect(retryResult.completed).toBe(1);
-                        expect(importManager.getFailedDocuments()).toHaveLength(0);
-                        expect((mockVault.create as jest.Mock).mock.calls.length).toBe(initialCreateCalls + 1);
-                        expect(retryProgressUpdates.length).toBeGreaterThan(0);
-                        expect(
-                                retryDocumentUpdates.some(
-                                        update => update.id === 'doc1' && update.status === 'completed'
-                                )
-                        ).toBe(true);
-                });
+			expect(retryResult.total).toBe(1);
+			expect(retryResult.failed).toBe(0);
+			expect(retryResult.completed).toBe(1);
+			expect(importManager.getFailedDocuments()).toHaveLength(0);
+			expect((mockVault.create as jest.Mock).mock.calls.length).toBe(initialCreateCalls + 1);
+			expect(retryProgressUpdates.length).toBeGreaterThan(0);
+			expect(
+				retryDocumentUpdates.some(
+					update => update.id === 'doc1' && update.status === 'completed'
+				)
+			).toBe(true);
+		});
 
-                it('throws when retrying without failed documents', async () => {
-                        await importManager.importDocuments(mockDocumentMetadata, mockGranolaDocuments, {
-                                ...defaultOptions,
-                                stopOnError: false,
-                        });
+		it('throws when retrying without failed documents', async () => {
+			await importManager.importDocuments(mockDocumentMetadata, mockGranolaDocuments, {
+				...defaultOptions,
+				stopOnError: false,
+			});
 
-                        await expect(
-                                importManager.retryFailedImports({ ...defaultOptions })
-                        ).rejects.toThrow('There are no failed documents to retry.');
-                });
-        });
+			await expect(importManager.retryFailedImports({ ...defaultOptions })).rejects.toThrow(
+				'There are no failed documents to retry.'
+			);
+		});
+	});
 
 	describe('empty document filtering', () => {
 		it('should skip empty documents when setting is enabled', async () => {

--- a/tests/unit/import-manager.test.ts
+++ b/tests/unit/import-manager.test.ts
@@ -578,8 +578,8 @@ describe('SelectiveImportManager', () => {
 
 	// Removed backup creation tests as createBackups option was removed
 
-	describe('edge cases and error recovery', () => {
-		it('should handle errors in handleImportError method', async () => {
+        describe('edge cases and error recovery', () => {
+                it('should handle errors in handleImportError method', async () => {
 			// Mock conversion to throw an error to trigger handleImportError
 			(mockConverter.convertDocument as jest.Mock).mockImplementationOnce(() => {
 				throw new Error('Critical conversion error');
@@ -864,8 +864,98 @@ describe('SelectiveImportManager', () => {
 			// The document should either be completed (if conflict resolution succeeds) or skipped
 			expect(result.completed + result.skipped).toBe(1);
 			expect(result.failed).toBe(0);
-		});
-	});
+                });
+        });
+
+        describe('failed import recovery features', () => {
+                it('tracks failed documents with metadata and error details', async () => {
+                        (mockConverter.convertDocument as jest.Mock).mockImplementation(doc => {
+                                if (doc.id === 'doc1') {
+                                        throw new Error('Conversion failed for doc1');
+                                }
+
+                                return {
+                                        filename: `${doc.id}.md`,
+                                        content: '# Markdown content',
+                                        frontmatter: { granola_id: doc.id, title: doc.title },
+                                        isTrulyEmpty: false,
+                                };
+                        });
+
+                        await importManager.importDocuments(mockDocumentMetadata, mockGranolaDocuments, {
+                                ...defaultOptions,
+                                stopOnError: false,
+                        });
+
+                        const failedRecords = importManager.getFailedDocuments();
+                        expect(failedRecords).toHaveLength(1);
+                        const failedRecord = failedRecords[0];
+                        expect(failedRecord.document.id).toBe('doc1');
+                        expect(failedRecord.metadata?.id).toBe('doc1');
+                        expect(failedRecord.metadata?.title).toBe('Document 1');
+                        expect(failedRecord.error).toContain('Conversion failed');
+                        expect(failedRecord.message).toContain('failed');
+                        expect(typeof failedRecord.timestamp).toBe('number');
+                });
+
+                it('retries only failed documents using stored context', async () => {
+                        let shouldFailDoc1 = true;
+                        (mockConverter.convertDocument as jest.Mock).mockImplementation(doc => {
+                                if (doc.id === 'doc1' && shouldFailDoc1) {
+                                        shouldFailDoc1 = false;
+                                        throw new Error('Initial failure for doc1');
+                                }
+
+                                return {
+                                        filename: `${doc.id}.md`,
+                                        content: '# Markdown content',
+                                        frontmatter: { granola_id: doc.id, title: doc.title },
+                                        isTrulyEmpty: false,
+                                };
+                        });
+
+                        await importManager.importDocuments(mockDocumentMetadata, mockGranolaDocuments, {
+                                ...defaultOptions,
+                                stopOnError: false,
+                        });
+
+                        const failedRecords = importManager.getFailedDocuments();
+                        expect(failedRecords).toHaveLength(1);
+                        const initialCreateCalls = (mockVault.create as jest.Mock).mock.calls.length;
+
+                        const retryProgressUpdates: ImportProgress[] = [];
+                        const retryDocumentUpdates: DocumentProgress[] = [];
+
+                        const retryResult = await importManager.retryFailedImports({
+                                ...defaultOptions,
+                                onProgress: progress => retryProgressUpdates.push(progress),
+                                onDocumentProgress: docProgress => retryDocumentUpdates.push(docProgress),
+                        });
+
+                        expect(retryResult.total).toBe(1);
+                        expect(retryResult.failed).toBe(0);
+                        expect(retryResult.completed).toBe(1);
+                        expect(importManager.getFailedDocuments()).toHaveLength(0);
+                        expect((mockVault.create as jest.Mock).mock.calls.length).toBe(initialCreateCalls + 1);
+                        expect(retryProgressUpdates.length).toBeGreaterThan(0);
+                        expect(
+                                retryDocumentUpdates.some(
+                                        update => update.id === 'doc1' && update.status === 'completed'
+                                )
+                        ).toBe(true);
+                });
+
+                it('throws when retrying without failed documents', async () => {
+                        await importManager.importDocuments(mockDocumentMetadata, mockGranolaDocuments, {
+                                ...defaultOptions,
+                                stopOnError: false,
+                        });
+
+                        await expect(
+                                importManager.retryFailedImports({ ...defaultOptions })
+                        ).rejects.toThrow('There are no failed documents to retry.');
+                });
+        });
 
 	describe('empty document filtering', () => {
 		it('should skip empty documents when setting is enabled', async () => {


### PR DESCRIPTION
## Summary
- track failed import attempts in the SelectiveImportManager and expose retry/export helpers
- extend the document selection modal with retry and export actions for failed imports
- document the new recovery workflow and add unit tests covering the manager and modal changes

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e1e4c7486c832caab01aaa7bf53176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Retry only failed imports, export failures as CSV or copyable summary, retry/export buttons in post-import UI, friendlier failure messages and timestamps, option to open imported notes.

- **Documentation**
  - Added “Recovering Failed Imports” to README; new GEMINI and QWEN project docs.

- **Bug Fixes / Improvements**
  - Improved HTML-to-Markdown text extraction and safer clipboard fallback behavior.

- **Tests**
  - Expanded tests for failure tracking, cloning safety, retry flows, conflicts, and progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->