### PR TITLE
Fix PR 38 review suggestions: Windows compatibility, clipboard API, and state preservation

### DIFF
--- a/src/services/import-manager.ts
+++ b/src/services/import-manager.ts
@@ -360,11 +360,9 @@ export class SelectiveImportManager {
 		// importDocuments calls startImport which calls reset(), clearing failedDocuments and
 		// lastImportMetadata. Keep this snapshot in-memory so metadata that contains Obsidian
 		// TFile references remains restorable even when those objects are not JSON-serializable.
-		const failedSnapshot = this.failedDocuments.map(record => ({
-			...record,
-			document: this.cloneDocument(record.document),
-			metadata: record.metadata ? this.cloneMetadata(record.metadata) : undefined,
-		}));
+		const failedSnapshot = this.failedDocuments.map(record =>
+			this.cloneFailedDocumentRecord(record)
+		);
 		const lastMetaSnapshot = new Map(
 			Array.from(this.lastImportMetadata.entries()).map(([key, value]) => [
 				key,
@@ -1142,6 +1140,14 @@ export class SelectiveImportManager {
 		return {
 			...metadata,
 			importStatus: { ...metadata.importStatus },
+		};
+	}
+
+	private cloneFailedDocumentRecord(record: FailedDocumentRecord): FailedDocumentRecord {
+		return {
+			...record,
+			document: this.cloneDocument(record.document),
+			metadata: record.metadata ? this.cloneMetadata(record.metadata) : undefined,
 		};
 	}
 

--- a/src/services/import-manager.ts
+++ b/src/services/import-manager.ts
@@ -358,8 +358,8 @@ export class SelectiveImportManager {
 
 		// Snapshot failed state before retry to prevent loss if importDocuments aborts early.
 		// importDocuments calls startImport which calls reset(), clearing failedDocuments and
-		// lastImportMetadata. If import throws synchronously before any processing, we restore
-		// the snapshot so users can still export or retry the original failure set.
+		// lastImportMetadata. Keep this snapshot in-memory so metadata that contains Obsidian
+		// TFile references remains restorable even when those objects are not JSON-serializable.
 		const failedSnapshot = this.failedDocuments.map(record => ({
 			...record,
 			document: this.cloneDocument(record.document),

--- a/src/ui/document-selection-modal.ts
+++ b/src/ui/document-selection-modal.ts
@@ -1057,11 +1057,32 @@ export class DocumentSelectionModal extends Modal {
 		const summary = this.buildFailedDocumentsSummary(records);
 
 		try {
-			// Use modern Clipboard API (available in Electron/Obsidian)
-			if (!navigator?.clipboard?.writeText) {
-				throw new Error('Clipboard API not available');
+			// Try modern Clipboard API first
+			if (navigator?.clipboard?.writeText) {
+				await navigator.clipboard.writeText(summary);
+			} else {
+				// Fallback to deprecated execCommand for older browsers
+				let textarea: HTMLTextAreaElement | null = null;
+				try {
+					textarea = document.createElement('textarea');
+					textarea.value = summary;
+					textarea.style.position = 'fixed';
+					textarea.style.opacity = '0';
+					document.body.appendChild(textarea);
+					textarea.focus();
+					textarea.select();
+
+					const successful = document.execCommand('copy');
+					if (!successful) {
+						throw new Error('document.execCommand("copy") failed');
+					}
+				} finally {
+					if (textarea && document.body.contains(textarea)) {
+						document.body.removeChild(textarea);
+					}
+				}
 			}
-			await navigator.clipboard.writeText(summary);
+
 			new Notice('Failed import summary copied to clipboard.');
 		} catch (error) {
 			console.error('[Granola Importer] Clipboard copy failed:', error);

--- a/src/ui/document-selection-modal.ts
+++ b/src/ui/document-selection-modal.ts
@@ -1033,7 +1033,7 @@ export class DocumentSelectionModal extends Modal {
 		const url = URL.createObjectURL(blob);
 		const link = document.createElement('a');
 		link.href = url;
-		link.download = `granola-failed-imports-${new Date().toISOString().replace(/:/g, '-')}.csv`;
+		link.download = this.buildFailedImportExportFilename();
 		document.body.appendChild(link);
 		link.click();
 		document.body.removeChild(link);
@@ -1077,9 +1077,7 @@ export class DocumentSelectionModal extends Modal {
 						throw new Error('document.execCommand("copy") failed');
 					}
 				} finally {
-					if (textarea && document.body.contains(textarea)) {
-						document.body.removeChild(textarea);
-					}
+					textarea?.remove();
 				}
 			}
 
@@ -1108,6 +1106,11 @@ export class DocumentSelectionModal extends Modal {
 		});
 
 		return [header, ...rows].join('\n');
+	}
+
+	private buildFailedImportExportFilename(): string {
+		const timestamp = new Date().toISOString().replace(/[<>:"/\\|?*]/g, '-');
+		return `granola-failed-imports-${timestamp}.csv`;
 	}
 
 	/**

--- a/tests/unit/document-selection-modal.test.ts
+++ b/tests/unit/document-selection-modal.test.ts
@@ -492,4 +492,51 @@ describe('DocumentSelectionModal', () => {
 			);
 		});
 	});
+
+	describe('failed import export helpers', () => {
+		it('sanitizes failed import export filenames for Windows-incompatible characters', () => {
+			const toISOStringSpy = jest
+				.spyOn(Date.prototype, 'toISOString')
+				.mockReturnValue('2026-04-26T23:45:00.123Z');
+
+			const filename = (modal as any).buildFailedImportExportFilename();
+
+			expect(filename).toBe('granola-failed-imports-2026-04-26T23-45-00.123Z.csv');
+			toISOStringSpy.mockRestore();
+		});
+
+		it('removes the fallback clipboard textarea after copying', async () => {
+			const textarea = document.createElementNS('http://www.w3.org/1999/xhtml', 'textarea');
+			const removeSpy = jest.spyOn(textarea, 'remove');
+			Object.defineProperty(global.navigator, 'clipboard', {
+				value: undefined,
+				configurable: true,
+			});
+			(global.document.createElement as jest.Mock).mockImplementation((tag: string) => {
+				if (tag === 'textarea') {
+					return textarea;
+				}
+
+				return {
+					textContent: '',
+					style: {},
+					appendChild: jest.fn(),
+				};
+			});
+			(global.document as any).execCommand = jest.fn().mockReturnValue(true);
+			const removeChildSpy = jest.spyOn(document.body, 'removeChild');
+
+			await (modal as any).copyFailedDocumentsToClipboard([
+				{
+					document: { id: 'doc1', title: 'Document 1' },
+					error: 'Boom',
+					message: 'Import failed',
+					timestamp: 1,
+				},
+			]);
+
+			expect(removeSpy).toHaveBeenCalled();
+			expect(removeChildSpy).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/tests/unit/import-manager.test.ts
+++ b/tests/unit/import-manager.test.ts
@@ -984,6 +984,43 @@ describe('SelectiveImportManager', () => {
 			).toBe(true);
 		});
 
+		it('preserves failed state snapshots when metadata contains circular TFile references', async () => {
+			const circularFile: any = { path: 'Existing.md' };
+			circularFile.self = circularFile;
+			const metadataWithExistingFile: DocumentDisplayMetadata = {
+				...mockDocumentMetadata[0],
+				importStatus: {
+					status: 'EXISTS',
+					reason: 'File already exists',
+					requiresUserChoice: true,
+					existingFile: circularFile,
+				},
+			};
+			(importManager as any).failedDocuments = [
+				{
+					document: mockGranolaDocuments[0],
+					metadata: metadataWithExistingFile,
+					error: 'Initial failure for doc1',
+					message: 'Import failed: Initial failure for doc1',
+					errorCategory: 'conversion',
+					timestamp: Date.now(),
+				},
+			];
+			(importManager as any).lastImportMetadata = new Map([
+				[mockGranolaDocuments[0].id, metadataWithExistingFile],
+			]);
+			jest.spyOn(importManager, 'importDocuments').mockRejectedValueOnce(
+				new Error('Retry aborted before processing')
+			);
+
+			await expect(importManager.retryFailedImports({ ...defaultOptions })).rejects.toThrow(
+				'Retry aborted before processing'
+			);
+
+			const [restoredRecord] = importManager.getFailedDocuments();
+			expect(restoredRecord.metadata?.importStatus.existingFile).toBe(circularFile);
+		});
+
 		it('throws when retrying without failed documents', async () => {
 			await importManager.importDocuments(mockDocumentMetadata, mockGranolaDocuments, {
 				...defaultOptions,


### PR DESCRIPTION
Addresses all sensible code review suggestions from Copilot and Coderabbit on PR 38.

**Changes:**
- Fix Prettier formatting violations
- Sanitize CSV filename for Windows (replace colons with dashes)
- Improve clipboard API with proper error handling and cleanup  
- Simplify type predicate using NonNullable
- Preserve failed import state on early retry failure with deep snapshots
- Clarify retry error notice

**Test Results:**
- All 450 tests passing
- Zero lint warnings
- TypeScript compilation successful
- Production build successful

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Recover failed imports: retry only failed documents with progress tracking.
  - New completion view actions: Retry failed imports, Export failed list, Open imported notes (when no failures).
  - Export options: download CSV of failures or copy a human-readable summary.
  - Improved notices and error handling during retry/copy/export.

- Documentation
  - Added guidance on recovering failed imports, retry scope, and export options; clarified that successful documents remain available.

- Tests
  - Added unit tests for failure tracking, retry behavior, and error handling; introduced menu mocks for UI flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->