### PR TITLE
Add event bus scaffolding and DI container

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -9,9 +9,9 @@ import { DocumentSelectionModal } from './src/ui/document-selection-modal';
 import { GranolaSettings, DEFAULT_SETTINGS, Logger } from './src/types';
 import { ServiceContainer } from './src/core/di/ServiceContainer';
 import {
-        PluginEvents,
-        VaultIndexerEventsAdapter,
-        CostTrackerEventsAdapter,
+	PluginEvents,
+	VaultIndexerEventsAdapter,
+	CostTrackerEventsAdapter,
 } from './src/core/events/PluginEvents';
 import { GranolaSettingTab } from './src/settings';
 
@@ -127,19 +127,19 @@ export default class GranolaImporterPlugin extends Plugin {
 	 * ```
 	 */
 	async onload(): Promise<void> {
-                try {
-                        await this.loadSettings();
-                        this.logger = new Logger(this.settings);
-                        this.logger.debug('Settings loaded and logger initialized');
-                } catch (error) {
+		try {
+			await this.loadSettings();
+			this.logger = new Logger(this.settings);
+			this.logger.debug('Settings loaded and logger initialized');
+		} catch (error) {
 			console.error('Fatal error during plugin initialization:', error);
 			throw error;
 		}
 
-                // Initialize core components
-                this.auth = new GranolaAuth();
-                this.api = new GranolaAPI(this.auth);
-                this.converter = new ProseMirrorConverter(this.logger, this.settings);
+		// Initialize core components
+		this.auth = new GranolaAuth();
+		this.api = new GranolaAPI(this.auth);
+		this.converter = new ProseMirrorConverter(this.logger, this.settings);
 
 		if (this.settings.plugin?.flags?.useEventBus) {
 			this.serviceContainer = new ServiceContainer();
@@ -148,7 +148,10 @@ export default class GranolaImporterPlugin extends Plugin {
 			const pluginEventsKey = Symbol.for('granola.plugin.events');
 			const pluginInstanceKey = Symbol.for('granola.plugin.instance');
 
-			this.serviceContainer.registerSingleton(pluginEventsKey, async () => this.pluginEvents!);
+			this.serviceContainer.registerSingleton(
+				pluginEventsKey,
+				async () => this.pluginEvents!
+			);
 			this.serviceContainer.registerSingleton(pluginInstanceKey, async () => this);
 
 			this.eventAdapters = [
@@ -156,7 +159,7 @@ export default class GranolaImporterPlugin extends Plugin {
 				new CostTrackerEventsAdapter(this.pluginEvents),
 			];
 
-                        await this.pluginEvents.emit('plugin:initialized');
+			await this.pluginEvents.emit('plugin:initialized');
 		}
 
 		// Initialize selective import services
@@ -226,7 +229,7 @@ export default class GranolaImporterPlugin extends Plugin {
 	 */
 	onunload(): void {
 		// Clean up resources when plugin is disabled
-		this.eventAdapters.forEach((adapter) => adapter.dispose());
+		this.eventAdapters.forEach(adapter => adapter.dispose());
 		this.eventAdapters = [];
 		this.pluginEvents?.clearAll();
 		this.serviceContainer?.clearScoped();
@@ -651,5 +654,5 @@ export default class GranolaImporterPlugin extends Plugin {
 		if (this.serviceContainer) {
 			await this.serviceContainer.reloadSettings(this.settings);
 		}
-        }
+	}
 }

--- a/main.ts
+++ b/main.ts
@@ -156,7 +156,7 @@ export default class GranolaImporterPlugin extends Plugin {
 				new CostTrackerEventsAdapter(this.pluginEvents),
 			];
 
-			await this.pluginEvents.emit('plugin:initialized', undefined);
+                        await this.pluginEvents.emit('plugin:initialized');
 		}
 
 		// Initialize selective import services

--- a/src/core/di/ServiceContainer.ts
+++ b/src/core/di/ServiceContainer.ts
@@ -80,7 +80,7 @@ export class ServiceContainer {
 
                         for (const registration of current.registrations.values()) {
                                 if (registration.onSettingsReload) {
-                                        await registration.onSettingsReload(settings, this);
+                                        await registration.onSettingsReload(settings, current);
                                 }
                         }
                 }
@@ -111,7 +111,7 @@ export class ServiceContainer {
                 }
 
                 if (this.parent) {
-                                return this.parent.lookup(identifier);
+                        return this.parent.lookup(identifier);
                 }
 
                 return undefined;

--- a/src/core/di/ServiceContainer.ts
+++ b/src/core/di/ServiceContainer.ts
@@ -1,0 +1,147 @@
+import type { GranolaSettings } from '../../types';
+
+export type ServiceIdentifier<T> = string | symbol;
+export type ServiceFactory<T> = (container: ServiceContainer) => T | Promise<T>;
+export type SettingsReloadHook = (settings: GranolaSettings, container: ServiceContainer) => void | Promise<void>;
+
+type ServiceScope = 'singleton' | 'scoped';
+
+interface ServiceRegistration<T> {
+        scope: ServiceScope;
+        factory: ServiceFactory<T>;
+        onSettingsReload?: SettingsReloadHook;
+}
+
+interface RegistrationRecord<T> {
+        container: ServiceContainer;
+        registration: ServiceRegistration<T>;
+}
+
+/**
+ * Minimal dependency injection container with support for singleton and scoped services.
+ */
+export class ServiceContainer {
+        private readonly registrations = new Map<ServiceIdentifier<unknown>, ServiceRegistration<unknown>>();
+        private readonly singletonCache = new Map<ServiceIdentifier<unknown>, Promise<unknown>>();
+        private readonly scopedCache = new Map<ServiceIdentifier<unknown>, Promise<unknown>>();
+
+        constructor(private readonly parent?: ServiceContainer) {}
+
+        registerSingleton<T>(
+                identifier: ServiceIdentifier<T>,
+                factory: ServiceFactory<T>,
+                options: { onSettingsReload?: SettingsReloadHook } = {}
+        ): void {
+                this.register(identifier, {
+                        scope: 'singleton',
+                        factory,
+                        onSettingsReload: options.onSettingsReload,
+                });
+        }
+
+        registerScoped<T>(
+                identifier: ServiceIdentifier<T>,
+                factory: ServiceFactory<T>,
+                options: { onSettingsReload?: SettingsReloadHook } = {}
+        ): void {
+                this.register(identifier, {
+                        scope: 'scoped',
+                        factory,
+                        onSettingsReload: options.onSettingsReload,
+                });
+        }
+
+        async resolve<T>(identifier: ServiceIdentifier<T>): Promise<T> {
+                const record = this.lookup(identifier);
+                if (!record) {
+                        throw new Error(`Service not registered for identifier: ${identifier.toString()}`);
+                }
+
+                const { registration, container } = record as RegistrationRecord<T>;
+                if (registration.scope === 'singleton') {
+                        return (await container.resolveSingleton(identifier, registration.factory, this)) as T;
+                }
+
+                return (await this.resolveScoped(identifier, registration.factory)) as T;
+        }
+
+        createScope(): ServiceContainer {
+                return new ServiceContainer(this);
+        }
+
+        async reloadSettings(settings: GranolaSettings): Promise<void> {
+                const visited = new Set<ServiceContainer>();
+                for (let current: ServiceContainer | undefined = this; current; current = current.parent) {
+                        if (visited.has(current)) {
+                                continue;
+                        }
+
+                        visited.add(current);
+
+                        for (const registration of current.registrations.values()) {
+                                if (registration.onSettingsReload) {
+                                        await registration.onSettingsReload(settings, this);
+                                }
+                        }
+                }
+        }
+
+        clearSingleton(identifier: ServiceIdentifier<unknown>): void {
+                this.singletonCache.delete(identifier);
+        }
+
+        clearScoped(): void {
+                this.scopedCache.clear();
+        }
+
+        private register<T>(identifier: ServiceIdentifier<T>, registration: ServiceRegistration<T>): void {
+                if (this.registrations.has(identifier)) {
+                        throw new Error(`Service already registered for identifier: ${identifier.toString()}`);
+                }
+
+                this.registrations.set(identifier, registration as ServiceRegistration<unknown>);
+        }
+
+        private lookup<T>(identifier: ServiceIdentifier<T>): RegistrationRecord<T> | undefined {
+                if (this.registrations.has(identifier)) {
+                        return {
+                                container: this,
+                                registration: this.registrations.get(identifier) as ServiceRegistration<T>,
+                        };
+                }
+
+                if (this.parent) {
+                                return this.parent.lookup(identifier);
+                }
+
+                return undefined;
+        }
+
+        private async resolveSingleton<T>(
+                identifier: ServiceIdentifier<T>,
+                factory: ServiceFactory<T>,
+                requester: ServiceContainer
+        ): Promise<T> {
+                if (!this.singletonCache.has(identifier)) {
+                        const instancePromise = Promise.resolve(factory(requester)).catch((error) => {
+                                this.singletonCache.delete(identifier);
+                                throw error;
+                        });
+                        this.singletonCache.set(identifier, instancePromise as Promise<unknown>);
+                }
+
+                return (await this.singletonCache.get(identifier)) as T;
+        }
+
+        private async resolveScoped<T>(identifier: ServiceIdentifier<T>, factory: ServiceFactory<T>): Promise<T> {
+                if (!this.scopedCache.has(identifier)) {
+                        const instancePromise = Promise.resolve(factory(this)).catch((error) => {
+                                this.scopedCache.delete(identifier);
+                                throw error;
+                        });
+                        this.scopedCache.set(identifier, instancePromise as Promise<unknown>);
+                }
+
+                return (await this.scopedCache.get(identifier)) as T;
+        }
+}

--- a/src/core/di/ServiceContainer.ts
+++ b/src/core/di/ServiceContainer.ts
@@ -1,6 +1,6 @@
 import type { GranolaSettings } from '../../types';
 
-export type ServiceIdentifier<T> = string | symbol;
+export type ServiceIdentifier<T> = (string | symbol) & { readonly __service?: T };
 export type ServiceFactory<T> = (container: ServiceContainer) => T | Promise<T>;
 export type SettingsReloadHook = (settings: GranolaSettings, container: ServiceContainer) => void | Promise<void>;
 

--- a/src/core/di/ServiceContainer.ts
+++ b/src/core/di/ServiceContainer.ts
@@ -2,146 +2,157 @@ import type { GranolaSettings } from '../../types';
 
 export type ServiceIdentifier<T> = (string | symbol) & { readonly __service?: T };
 export type ServiceFactory<T> = (container: ServiceContainer) => T | Promise<T>;
-export type SettingsReloadHook = (settings: GranolaSettings, container: ServiceContainer) => void | Promise<void>;
+export type SettingsReloadHook = (
+	settings: GranolaSettings,
+	container: ServiceContainer
+) => void | Promise<void>;
 
 type ServiceScope = 'singleton' | 'scoped';
 
 interface ServiceRegistration<T> {
-        scope: ServiceScope;
-        factory: ServiceFactory<T>;
-        onSettingsReload?: SettingsReloadHook;
+	scope: ServiceScope;
+	factory: ServiceFactory<T>;
+	onSettingsReload?: SettingsReloadHook;
 }
 
 interface RegistrationRecord<T> {
-        container: ServiceContainer;
-        registration: ServiceRegistration<T>;
+	container: ServiceContainer;
+	registration: ServiceRegistration<T>;
 }
 
 /**
  * Minimal dependency injection container with support for singleton and scoped services.
  */
 export class ServiceContainer {
-        private readonly registrations = new Map<ServiceIdentifier<unknown>, ServiceRegistration<unknown>>();
-        private readonly singletonCache = new Map<ServiceIdentifier<unknown>, Promise<unknown>>();
-        private readonly scopedCache = new Map<ServiceIdentifier<unknown>, Promise<unknown>>();
+	private readonly registrations = new Map<
+		ServiceIdentifier<unknown>,
+		ServiceRegistration<unknown>
+	>();
+	private readonly singletonCache = new Map<ServiceIdentifier<unknown>, Promise<unknown>>();
+	private readonly scopedCache = new Map<ServiceIdentifier<unknown>, Promise<unknown>>();
 
-        constructor(private readonly parent?: ServiceContainer) {}
+	constructor(private readonly parent?: ServiceContainer) {}
 
-        registerSingleton<T>(
-                identifier: ServiceIdentifier<T>,
-                factory: ServiceFactory<T>,
-                options: { onSettingsReload?: SettingsReloadHook } = {}
-        ): void {
-                this.register(identifier, {
-                        scope: 'singleton',
-                        factory,
-                        onSettingsReload: options.onSettingsReload,
-                });
-        }
+	registerSingleton<T>(
+		identifier: ServiceIdentifier<T>,
+		factory: ServiceFactory<T>,
+		options: { onSettingsReload?: SettingsReloadHook } = {}
+	): void {
+		this.register(identifier, {
+			scope: 'singleton',
+			factory,
+			onSettingsReload: options.onSettingsReload,
+		});
+	}
 
-        registerScoped<T>(
-                identifier: ServiceIdentifier<T>,
-                factory: ServiceFactory<T>,
-                options: { onSettingsReload?: SettingsReloadHook } = {}
-        ): void {
-                this.register(identifier, {
-                        scope: 'scoped',
-                        factory,
-                        onSettingsReload: options.onSettingsReload,
-                });
-        }
+	registerScoped<T>(
+		identifier: ServiceIdentifier<T>,
+		factory: ServiceFactory<T>,
+		options: { onSettingsReload?: SettingsReloadHook } = {}
+	): void {
+		this.register(identifier, {
+			scope: 'scoped',
+			factory,
+			onSettingsReload: options.onSettingsReload,
+		});
+	}
 
-        async resolve<T>(identifier: ServiceIdentifier<T>): Promise<T> {
-                const record = this.lookup(identifier);
-                if (!record) {
-                        throw new Error(`Service not registered for identifier: ${identifier.toString()}`);
-                }
+	async resolve<T>(identifier: ServiceIdentifier<T>): Promise<T> {
+		const record = this.lookup(identifier);
+		if (!record) {
+			throw new Error(`Service not registered for identifier: ${identifier.toString()}`);
+		}
 
-                const { registration, container } = record as RegistrationRecord<T>;
-                if (registration.scope === 'singleton') {
-                        return (await container.resolveSingleton(identifier, registration.factory, this)) as T;
-                }
+		const { registration, container } = record as RegistrationRecord<T>;
+		if (registration.scope === 'singleton') {
+			return (await container.resolveSingleton(identifier, registration.factory)) as T;
+		}
 
-                return (await this.resolveScoped(identifier, registration.factory)) as T;
-        }
+		return (await this.resolveScoped(identifier, registration.factory)) as T;
+	}
 
-        createScope(): ServiceContainer {
-                return new ServiceContainer(this);
-        }
+	createScope(): ServiceContainer {
+		return new ServiceContainer(this);
+	}
 
-        async reloadSettings(settings: GranolaSettings): Promise<void> {
-                const visited = new Set<ServiceContainer>();
-                for (let current: ServiceContainer | undefined = this; current; current = current.parent) {
-                        if (visited.has(current)) {
-                                continue;
-                        }
+	async reloadSettings(settings: GranolaSettings): Promise<void> {
+		const visited = new Set<ServiceContainer>();
+		for (let current: ServiceContainer | undefined = this; current; current = current.parent) {
+			if (visited.has(current)) {
+				continue;
+			}
 
-                        visited.add(current);
+			visited.add(current);
 
-                        for (const registration of current.registrations.values()) {
-                                if (registration.onSettingsReload) {
-                                        await registration.onSettingsReload(settings, current);
-                                }
-                        }
-                }
-        }
+			for (const registration of current.registrations.values()) {
+				if (registration.onSettingsReload) {
+					await registration.onSettingsReload(settings, current);
+				}
+			}
+		}
+	}
 
-        clearSingleton(identifier: ServiceIdentifier<unknown>): void {
-                this.singletonCache.delete(identifier);
-        }
+	clearSingleton(identifier: ServiceIdentifier<unknown>): void {
+		this.singletonCache.delete(identifier);
+	}
 
-        clearScoped(): void {
-                this.scopedCache.clear();
-        }
+	clearScoped(): void {
+		this.scopedCache.clear();
+	}
 
-        private register<T>(identifier: ServiceIdentifier<T>, registration: ServiceRegistration<T>): void {
-                if (this.registrations.has(identifier)) {
-                        throw new Error(`Service already registered for identifier: ${identifier.toString()}`);
-                }
+	private register<T>(
+		identifier: ServiceIdentifier<T>,
+		registration: ServiceRegistration<T>
+	): void {
+		if (this.registrations.has(identifier)) {
+			throw new Error(`Service already registered for identifier: ${identifier.toString()}`);
+		}
 
-                this.registrations.set(identifier, registration as ServiceRegistration<unknown>);
-        }
+		this.registrations.set(identifier, registration as ServiceRegistration<unknown>);
+	}
 
-        private lookup<T>(identifier: ServiceIdentifier<T>): RegistrationRecord<T> | undefined {
-                if (this.registrations.has(identifier)) {
-                        return {
-                                container: this,
-                                registration: this.registrations.get(identifier) as ServiceRegistration<T>,
-                        };
-                }
+	private lookup<T>(identifier: ServiceIdentifier<T>): RegistrationRecord<T> | undefined {
+		if (this.registrations.has(identifier)) {
+			return {
+				container: this,
+				registration: this.registrations.get(identifier) as ServiceRegistration<T>,
+			};
+		}
 
-                if (this.parent) {
-                        return this.parent.lookup(identifier);
-                }
+		if (this.parent) {
+			return this.parent.lookup(identifier);
+		}
 
-                return undefined;
-        }
+		return undefined;
+	}
 
-        private async resolveSingleton<T>(
-                identifier: ServiceIdentifier<T>,
-                factory: ServiceFactory<T>,
-                requester: ServiceContainer
-        ): Promise<T> {
-                if (!this.singletonCache.has(identifier)) {
-                        const instancePromise = Promise.resolve(factory(requester)).catch((error) => {
-                                this.singletonCache.delete(identifier);
-                                throw error;
-                        });
-                        this.singletonCache.set(identifier, instancePromise as Promise<unknown>);
-                }
+	private async resolveSingleton<T>(
+		identifier: ServiceIdentifier<T>,
+		factory: ServiceFactory<T>
+	): Promise<T> {
+		if (!this.singletonCache.has(identifier)) {
+			const instancePromise = Promise.resolve(factory(this)).catch(error => {
+				this.singletonCache.delete(identifier);
+				throw error;
+			});
+			this.singletonCache.set(identifier, instancePromise as Promise<unknown>);
+		}
 
-                return (await this.singletonCache.get(identifier)) as T;
-        }
+		return (await this.singletonCache.get(identifier)) as T;
+	}
 
-        private async resolveScoped<T>(identifier: ServiceIdentifier<T>, factory: ServiceFactory<T>): Promise<T> {
-                if (!this.scopedCache.has(identifier)) {
-                        const instancePromise = Promise.resolve(factory(this)).catch((error) => {
-                                this.scopedCache.delete(identifier);
-                                throw error;
-                        });
-                        this.scopedCache.set(identifier, instancePromise as Promise<unknown>);
-                }
+	private async resolveScoped<T>(
+		identifier: ServiceIdentifier<T>,
+		factory: ServiceFactory<T>
+	): Promise<T> {
+		if (!this.scopedCache.has(identifier)) {
+			const instancePromise = Promise.resolve(factory(this)).catch(error => {
+				this.scopedCache.delete(identifier);
+				throw error;
+			});
+			this.scopedCache.set(identifier, instancePromise as Promise<unknown>);
+		}
 
-                return (await this.scopedCache.get(identifier)) as T;
-        }
+		return (await this.scopedCache.get(identifier)) as T;
+	}
 }

--- a/src/core/events/PluginEvents.ts
+++ b/src/core/events/PluginEvents.ts
@@ -1,190 +1,204 @@
 export interface PluginEventMap {
-        'plugin:initialized': void;
-        'vault:indexer:initialized': { timestamp: number };
-        'vault:indexer:updated': { progress: number };
-        'cost-tracker:updated': { total: number };
-        'cost-tracker:reset': void;
+	'plugin:initialized': void;
+	'vault:indexer:initialized': { timestamp: number };
+	'vault:indexer:updated': { progress: number };
+	'cost-tracker:updated': { total: number };
+	'cost-tracker:reset': void;
 }
 
 type EventHandler<T> = (payload: T) => void | Promise<void>;
 
 export interface PluginEventSubscription {
-        unsubscribe(): void;
+	unsubscribe(): void;
 }
 
 /**
  * Lightweight typed event emitter for orchestrating plugin subsystems.
  */
 export class PluginEvents {
-        private readonly handlers = new Map<keyof PluginEventMap, Set<EventHandler<unknown>>>();
+	private readonly handlers = new Map<keyof PluginEventMap, Set<EventHandler<unknown>>>();
 
-        subscribe<K extends keyof PluginEventMap>(event: K, handler: EventHandler<PluginEventMap[K]>): PluginEventSubscription {
-                const handlerSet = this.getHandlerSet(event);
-                handlerSet.add(handler as EventHandler<unknown>);
-                return {
-                        unsubscribe: () => {
-                                this.unsubscribe(event, handler);
-                        },
-                };
-        }
+	subscribe<K extends keyof PluginEventMap>(
+		event: K,
+		handler: EventHandler<PluginEventMap[K]>
+	): PluginEventSubscription {
+		const handlerSet = this.getHandlerSet(event);
+		handlerSet.add(handler as EventHandler<unknown>);
+		return {
+			unsubscribe: () => {
+				this.unsubscribe(event, handler);
+			},
+		};
+	}
 
-        subscribeOnce<K extends keyof PluginEventMap>(
-                event: K,
-                handler: EventHandler<PluginEventMap[K]>
-        ): PluginEventSubscription {
-                const subscription = this.subscribe(event, async (payload) => {
-                        try {
-                                await handler(payload);
-                        } finally {
-                                subscription.unsubscribe();
-                        }
-                });
-                return subscription;
-        }
+	subscribeOnce<K extends keyof PluginEventMap>(
+		event: K,
+		handler: EventHandler<PluginEventMap[K]>
+	): PluginEventSubscription {
+		const subscription = this.subscribe(event, async payload => {
+			try {
+				await handler(payload);
+			} finally {
+				subscription.unsubscribe();
+			}
+		});
+		return subscription;
+	}
 
-        async emit<K extends keyof PluginEventMap>(
-                event: K,
-                ...[payload]: PluginEventMap[K] extends void
-                        ? [payload?: PluginEventMap[K]]
-                        : [payload: PluginEventMap[K]]
-        ): Promise<void> {
-                const handlerSet = this.handlers.get(event);
-                if (!handlerSet || handlerSet.size === 0) {
-                        return;
-                }
+	async emit<K extends keyof PluginEventMap>(
+		event: K,
+		...[payload]: PluginEventMap[K] extends void
+			? [payload?: PluginEventMap[K]]
+			: [payload: PluginEventMap[K]]
+	): Promise<void> {
+		const handlerSet = this.handlers.get(event);
+		if (!handlerSet || handlerSet.size === 0) {
+			return;
+		}
 
-                const handlers = Array.from(handlerSet) as EventHandler<PluginEventMap[K]>[];
-                await Promise.all(
-                        handlers.map(async (handler) => {
-                                await handler(payload as PluginEventMap[K]);
-                        })
-                );
-        }
+		const handlers = Array.from(handlerSet) as EventHandler<PluginEventMap[K]>[];
+		await Promise.all(
+			handlers.map(async handler => {
+				await handler(payload as PluginEventMap[K]);
+			})
+		);
+	}
 
-        unsubscribe<K extends keyof PluginEventMap>(event: K, handler: EventHandler<PluginEventMap[K]>): void {
-                const handlerSet = this.handlers.get(event);
-                if (!handlerSet) {
-                        return;
-                }
+	unsubscribe<K extends keyof PluginEventMap>(
+		event: K,
+		handler: EventHandler<PluginEventMap[K]>
+	): void {
+		const handlerSet = this.handlers.get(event);
+		if (!handlerSet) {
+			return;
+		}
 
-                handlerSet.delete(handler as EventHandler<unknown>);
-                if (handlerSet.size === 0) {
-                        this.handlers.delete(event);
-                }
-        }
+		handlerSet.delete(handler as EventHandler<unknown>);
+		if (handlerSet.size === 0) {
+			this.handlers.delete(event);
+		}
+	}
 
-        clearAll(): void {
-                this.handlers.clear();
-        }
+	clearAll(): void {
+		this.handlers.clear();
+	}
 
-        createScope(): PluginEventScope {
-                return new PluginEventScope(this);
-        }
+	createScope(): PluginEventScope {
+		return new PluginEventScope(this);
+	}
 
-        private getHandlerSet<K extends keyof PluginEventMap>(event: K): Set<EventHandler<unknown>> {
-                if (!this.handlers.has(event)) {
-                        this.handlers.set(event, new Set());
-                }
+	private getHandlerSet<K extends keyof PluginEventMap>(event: K): Set<EventHandler<unknown>> {
+		if (!this.handlers.has(event)) {
+			this.handlers.set(event, new Set());
+		}
 
-                return this.handlers.get(event)!;
-        }
+		return this.handlers.get(event)!;
+	}
 }
 
 /**
  * Utility for managing grouped subscriptions with automatic disposal.
  */
 export class PluginEventScope {
-        private readonly subscriptions = new Set<PluginEventSubscription>();
+	private readonly subscriptions = new Set<PluginEventSubscription>();
 
-        constructor(private readonly events: PluginEvents) {}
+	constructor(private readonly events: PluginEvents) {}
 
-        on<K extends keyof PluginEventMap>(event: K, handler: EventHandler<PluginEventMap[K]>): PluginEventSubscription {
-                const subscription = this.events.subscribe(event, handler);
-                const scopedSubscription: PluginEventSubscription = {
-                        unsubscribe: () => {
-                                this.subscriptions.delete(scopedSubscription);
-                                subscription.unsubscribe();
-                        },
-                };
-                this.subscriptions.add(scopedSubscription);
-                return scopedSubscription;
-        }
+	on<K extends keyof PluginEventMap>(
+		event: K,
+		handler: EventHandler<PluginEventMap[K]>
+	): PluginEventSubscription {
+		const subscription = this.events.subscribe(event, handler);
+		const scopedSubscription: PluginEventSubscription = {
+			unsubscribe: () => {
+				this.subscriptions.delete(scopedSubscription);
+				subscription.unsubscribe();
+			},
+		};
+		this.subscriptions.add(scopedSubscription);
+		return scopedSubscription;
+	}
 
-        once<K extends keyof PluginEventMap>(event: K, handler: EventHandler<PluginEventMap[K]>): PluginEventSubscription {
-                const subscription = this.events.subscribeOnce(event, handler);
-                const scopedSubscription: PluginEventSubscription = {
-                        unsubscribe: () => {
-                                this.subscriptions.delete(scopedSubscription);
-                                subscription.unsubscribe();
-                        },
-                };
-                this.subscriptions.add(scopedSubscription);
-                return scopedSubscription;
-        }
+	once<K extends keyof PluginEventMap>(
+		event: K,
+		handler: EventHandler<PluginEventMap[K]>
+	): PluginEventSubscription {
+		const subscription = this.events.subscribeOnce(event, handler);
+		const scopedSubscription: PluginEventSubscription = {
+			unsubscribe: () => {
+				this.subscriptions.delete(scopedSubscription);
+				subscription.unsubscribe();
+			},
+		};
+		this.subscriptions.add(scopedSubscription);
+		return scopedSubscription;
+	}
 
-        dispose(): void {
-                for (const subscription of this.subscriptions) {
-                        subscription.unsubscribe();
-                }
-                this.subscriptions.clear();
-        }
+	dispose(): void {
+		for (const subscription of this.subscriptions) {
+			subscription.unsubscribe();
+		}
+		this.subscriptions.clear();
+	}
 }
 
 /**
  * Stub adapter for wiring the vault indexer to the shared event bus.
  */
 export class VaultIndexerEventsAdapter {
-        private readonly scope: PluginEventScope;
+	private readonly scope: PluginEventScope;
 
-        constructor(events: PluginEvents) {
-                this.scope = events.createScope();
-                this.register();
-        }
+	constructor(events: PluginEvents) {
+		this.scope = events.createScope();
+		this.register();
+	}
 
-        dispose(): void {
-                this.scope.dispose();
-        }
+	dispose(): void {
+		this.scope.dispose();
+	}
 
-        private register(): void {
-                this.scope.on('vault:indexer:initialized', this.handleInitialized);
-                this.scope.on('vault:indexer:updated', this.handleUpdated);
-        }
+	private register(): void {
+		this.scope.on('vault:indexer:initialized', this.handleInitialized);
+		this.scope.on('vault:indexer:updated', this.handleUpdated);
+	}
 
-        // Placeholder handlers for future implementations
-        private readonly handleInitialized = async (_payload: PluginEventMap['vault:indexer:initialized']) => {
-                return;
-        };
+	// Placeholder handlers for future implementations
+	private readonly handleInitialized = async (
+		_payload: PluginEventMap['vault:indexer:initialized']
+	) => {
+		return;
+	};
 
-        private readonly handleUpdated = async (_payload: PluginEventMap['vault:indexer:updated']) => {
-                return;
-        };
+	private readonly handleUpdated = async (_payload: PluginEventMap['vault:indexer:updated']) => {
+		return;
+	};
 }
 
 /**
  * Stub adapter for wiring the cost tracker to the shared event bus.
  */
 export class CostTrackerEventsAdapter {
-        private readonly scope: PluginEventScope;
+	private readonly scope: PluginEventScope;
 
-        constructor(events: PluginEvents) {
-                this.scope = events.createScope();
-                this.register();
-        }
+	constructor(events: PluginEvents) {
+		this.scope = events.createScope();
+		this.register();
+	}
 
-        dispose(): void {
-                this.scope.dispose();
-        }
+	dispose(): void {
+		this.scope.dispose();
+	}
 
-        private register(): void {
-                this.scope.on('cost-tracker:updated', this.handleUpdated);
-                this.scope.on('cost-tracker:reset', this.handleReset);
-        }
+	private register(): void {
+		this.scope.on('cost-tracker:updated', this.handleUpdated);
+		this.scope.on('cost-tracker:reset', this.handleReset);
+	}
 
-        private readonly handleUpdated = async (_payload: PluginEventMap['cost-tracker:updated']) => {
-                return;
-        };
+	private readonly handleUpdated = async (_payload: PluginEventMap['cost-tracker:updated']) => {
+		return;
+	};
 
-        private readonly handleReset = async (_payload: PluginEventMap['cost-tracker:reset']) => {
-                return;
-        };
+	private readonly handleReset = async (_payload: PluginEventMap['cost-tracker:reset']) => {
+		return;
+	};
 }

--- a/src/core/events/PluginEvents.ts
+++ b/src/core/events/PluginEvents.ts
@@ -1,0 +1,173 @@
+export interface PluginEventMap {
+        'plugin:initialized': void;
+        'vault:indexer:initialized': { timestamp: number };
+        'vault:indexer:updated': { progress: number };
+        'cost-tracker:updated': { total: number };
+        'cost-tracker:reset': void;
+}
+
+type EventHandler<T> = (payload: T) => void | Promise<void>;
+
+export interface PluginEventSubscription {
+        unsubscribe(): void;
+}
+
+/**
+ * Lightweight typed event emitter for orchestrating plugin subsystems.
+ */
+export class PluginEvents {
+        private readonly handlers = new Map<keyof PluginEventMap, Set<EventHandler<unknown>>>();
+
+        subscribe<K extends keyof PluginEventMap>(event: K, handler: EventHandler<PluginEventMap[K]>): PluginEventSubscription {
+                const handlerSet = this.getHandlerSet(event);
+                handlerSet.add(handler as EventHandler<unknown>);
+                return {
+                        unsubscribe: () => {
+                                this.unsubscribe(event, handler);
+                        },
+                };
+        }
+
+        subscribeOnce<K extends keyof PluginEventMap>(
+                event: K,
+                handler: EventHandler<PluginEventMap[K]>
+        ): PluginEventSubscription {
+                const subscription = this.subscribe(event, async (payload) => {
+                        try {
+                                await handler(payload);
+                        } finally {
+                                subscription.unsubscribe();
+                        }
+                });
+                return subscription;
+        }
+
+        async emit<K extends keyof PluginEventMap>(event: K, payload: PluginEventMap[K]): Promise<void> {
+                const handlerSet = this.handlers.get(event);
+                if (!handlerSet || handlerSet.size === 0) {
+                        return;
+                }
+
+                const handlers = Array.from(handlerSet) as EventHandler<PluginEventMap[K]>[];
+                await Promise.all(
+                        handlers.map(async (handler) => {
+                                await handler(payload);
+                        })
+                );
+        }
+
+        unsubscribe<K extends keyof PluginEventMap>(event: K, handler: EventHandler<PluginEventMap[K]>): void {
+                const handlerSet = this.handlers.get(event);
+                if (!handlerSet) {
+                        return;
+                }
+
+                handlerSet.delete(handler as EventHandler<unknown>);
+                if (handlerSet.size === 0) {
+                        this.handlers.delete(event);
+                }
+        }
+
+        clearAll(): void {
+                this.handlers.clear();
+        }
+
+        createScope(): PluginEventScope {
+                return new PluginEventScope(this);
+        }
+
+        private getHandlerSet<K extends keyof PluginEventMap>(event: K): Set<EventHandler<unknown>> {
+                if (!this.handlers.has(event)) {
+                        this.handlers.set(event, new Set());
+                }
+
+                return this.handlers.get(event)!;
+        }
+}
+
+/**
+ * Utility for managing grouped subscriptions with automatic disposal.
+ */
+export class PluginEventScope {
+        private readonly subscriptions = new Set<PluginEventSubscription>();
+
+        constructor(private readonly events: PluginEvents) {}
+
+        on<K extends keyof PluginEventMap>(event: K, handler: EventHandler<PluginEventMap[K]>): PluginEventSubscription {
+                const subscription = this.events.subscribe(event, handler);
+                this.subscriptions.add(subscription);
+                return subscription;
+        }
+
+        once<K extends keyof PluginEventMap>(event: K, handler: EventHandler<PluginEventMap[K]>): PluginEventSubscription {
+                const subscription = this.events.subscribeOnce(event, handler);
+                this.subscriptions.add(subscription);
+                return subscription;
+        }
+
+        dispose(): void {
+                for (const subscription of this.subscriptions) {
+                        subscription.unsubscribe();
+                }
+                this.subscriptions.clear();
+        }
+}
+
+/**
+ * Stub adapter for wiring the vault indexer to the shared event bus.
+ */
+export class VaultIndexerEventsAdapter {
+        private readonly scope: PluginEventScope;
+
+        constructor(events: PluginEvents) {
+                this.scope = events.createScope();
+                this.register();
+        }
+
+        dispose(): void {
+                this.scope.dispose();
+        }
+
+        private register(): void {
+                this.scope.on('vault:indexer:initialized', this.handleInitialized);
+                this.scope.on('vault:indexer:updated', this.handleUpdated);
+        }
+
+        // Placeholder handlers for future implementations
+        private readonly handleInitialized = async (_payload: PluginEventMap['vault:indexer:initialized']) => {
+                return;
+        };
+
+        private readonly handleUpdated = async (_payload: PluginEventMap['vault:indexer:updated']) => {
+                return;
+        };
+}
+
+/**
+ * Stub adapter for wiring the cost tracker to the shared event bus.
+ */
+export class CostTrackerEventsAdapter {
+        private readonly scope: PluginEventScope;
+
+        constructor(events: PluginEvents) {
+                this.scope = events.createScope();
+                this.register();
+        }
+
+        dispose(): void {
+                this.scope.dispose();
+        }
+
+        private register(): void {
+                this.scope.on('cost-tracker:updated', this.handleUpdated);
+                this.scope.on('cost-tracker:reset', this.handleReset);
+        }
+
+        private readonly handleUpdated = async (_payload: PluginEventMap['cost-tracker:updated']) => {
+                return;
+        };
+
+        private readonly handleReset = async (_payload: PluginEventMap['cost-tracker:reset']) => {
+                return;
+        };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,22 +54,22 @@ export enum ContentPriority {
  * Plugin settings interface with simplified configuration options.
  */
 export interface GranolaSettings {
-        /** Debug and logging settings */
-        debug: {
-                /** Enable debug logging */
-                enabled: boolean;
-                /** Log level threshold */
-                logLevel: LogLevel;
-        };
+	/** Debug and logging settings */
+	debug: {
+		/** Enable debug logging */
+		enabled: boolean;
+		/** Log level threshold */
+		logLevel: LogLevel;
+	};
 
-        /** Experimental plugin feature flags */
-        plugin: {
-                /** Flags that enable in-development functionality */
-                flags: {
-                        /** Toggle for the internal event bus scaffolding */
-                        useEventBus: boolean;
-                };
-        };
+	/** Experimental plugin feature flags */
+	plugin: {
+		/** Flags that enable in-development functionality */
+		flags: {
+			/** Toggle for the internal event bus scaffolding */
+			useEventBus: boolean;
+		};
+	};
 
 	/** Import behavior settings */
 	import: {
@@ -144,15 +144,15 @@ export interface GranolaSettings {
  * Default settings with sensible values.
  */
 export const DEFAULT_SETTINGS: GranolaSettings = {
-        debug: {
-                enabled: false,
-                logLevel: LogLevel.WARN,
-        },
-        plugin: {
-                flags: {
-                        useEventBus: false,
-                },
-        },
+	debug: {
+		enabled: false,
+		logLevel: LogLevel.WARN,
+	},
+	plugin: {
+		flags: {
+			useEventBus: false,
+		},
+	},
 	import: {
 		strategy: ImportStrategy.ALWAYS_PROMPT,
 		defaultFolder: '',

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,13 +54,22 @@ export enum ContentPriority {
  * Plugin settings interface with simplified configuration options.
  */
 export interface GranolaSettings {
-	/** Debug and logging settings */
-	debug: {
-		/** Enable debug logging */
-		enabled: boolean;
-		/** Log level threshold */
-		logLevel: LogLevel;
-	};
+        /** Debug and logging settings */
+        debug: {
+                /** Enable debug logging */
+                enabled: boolean;
+                /** Log level threshold */
+                logLevel: LogLevel;
+        };
+
+        /** Experimental plugin feature flags */
+        plugin: {
+                /** Flags that enable in-development functionality */
+                flags: {
+                        /** Toggle for the internal event bus scaffolding */
+                        useEventBus: boolean;
+                };
+        };
 
 	/** Import behavior settings */
 	import: {
@@ -135,10 +144,15 @@ export interface GranolaSettings {
  * Default settings with sensible values.
  */
 export const DEFAULT_SETTINGS: GranolaSettings = {
-	debug: {
-		enabled: false,
-		logLevel: LogLevel.WARN,
-	},
+        debug: {
+                enabled: false,
+                logLevel: LogLevel.WARN,
+        },
+        plugin: {
+                flags: {
+                        useEventBus: false,
+                },
+        },
 	import: {
 		strategy: ImportStrategy.ALWAYS_PROMPT,
 		defaultFolder: '',

--- a/tests/unit/plugin-events.test.ts
+++ b/tests/unit/plugin-events.test.ts
@@ -34,18 +34,33 @@ describe('PluginEvents', () => {
                 const handler = jest.fn();
 
                 scope.on('plugin:initialized', handler);
-                await events.emit('plugin:initialized', undefined);
+                await events.emit('plugin:initialized');
                 expect(handler).toHaveBeenCalledTimes(1);
 
                 scope.dispose();
-                await events.emit('plugin:initialized', undefined);
+                await events.emit('plugin:initialized');
                 expect(handler).toHaveBeenCalledTimes(1);
 
                 const anotherHandler = jest.fn();
                 events.subscribe('cost-tracker:reset', anotherHandler);
                 events.clearAll();
-                await events.emit('cost-tracker:reset', undefined);
+                await events.emit('cost-tracker:reset');
                 expect(anotherHandler).not.toHaveBeenCalled();
+        });
+
+        it('removes scoped subscriptions when manually unsubscribed', async () => {
+                const events = new PluginEvents();
+                const scope = new PluginEventScope(events);
+                const handler = jest.fn();
+
+                const subscription = scope.on('cost-tracker:reset', handler);
+                subscription.unsubscribe();
+
+                await events.emit('cost-tracker:reset');
+
+                expect(handler).not.toHaveBeenCalled();
+
+                scope.dispose();
         });
 });
 

--- a/tests/unit/plugin-events.test.ts
+++ b/tests/unit/plugin-events.test.ts
@@ -1,0 +1,100 @@
+import {
+        PluginEvents,
+        PluginEventScope,
+        VaultIndexerEventsAdapter,
+        CostTrackerEventsAdapter,
+} from '../../src/core/events/PluginEvents';
+
+describe('PluginEvents', () => {
+        it('notifies subscribers with typed payloads', async () => {
+                const events = new PluginEvents();
+                const handler = jest.fn();
+
+                events.subscribe('cost-tracker:updated', handler);
+                await events.emit('cost-tracker:updated', { total: 42 });
+
+                expect(handler).toHaveBeenCalledWith({ total: 42 });
+        });
+
+        it('supports one-time subscriptions', async () => {
+                const events = new PluginEvents();
+                const handler = jest.fn();
+
+                events.subscribeOnce('vault:indexer:updated', handler);
+                await events.emit('vault:indexer:updated', { progress: 0.5 });
+                await events.emit('vault:indexer:updated', { progress: 0.9 });
+
+                expect(handler).toHaveBeenCalledTimes(1);
+                expect(handler).toHaveBeenCalledWith({ progress: 0.5 });
+        });
+
+        it('clears subscriptions via scopes and clearAll', async () => {
+                const events = new PluginEvents();
+                const scope = new PluginEventScope(events);
+                const handler = jest.fn();
+
+                scope.on('plugin:initialized', handler);
+                await events.emit('plugin:initialized', undefined);
+                expect(handler).toHaveBeenCalledTimes(1);
+
+                scope.dispose();
+                await events.emit('plugin:initialized', undefined);
+                expect(handler).toHaveBeenCalledTimes(1);
+
+                const anotherHandler = jest.fn();
+                events.subscribe('cost-tracker:reset', anotherHandler);
+                events.clearAll();
+                await events.emit('cost-tracker:reset', undefined);
+                expect(anotherHandler).not.toHaveBeenCalled();
+        });
+});
+
+describe('Plugin event adapters', () => {
+        it('registers vault indexer adapter handlers when constructed', async () => {
+                const events = new PluginEvents();
+                const subscribeSpy = jest.spyOn(events, 'subscribe');
+
+                const adapter = new VaultIndexerEventsAdapter(events);
+
+                expect(subscribeSpy).toHaveBeenCalledWith(
+                        'vault:indexer:initialized',
+                        (adapter as unknown as { handleInitialized: unknown }).handleInitialized
+                );
+                expect(subscribeSpy).toHaveBeenCalledWith(
+                        'vault:indexer:updated',
+                        (adapter as unknown as { handleUpdated: unknown }).handleUpdated
+                );
+
+                const registeredHandler = subscribeSpy.mock.calls[0][1] as (payload: unknown) => Promise<void>;
+                await expect(registeredHandler({ timestamp: Date.now() })).resolves.toBeUndefined();
+
+                adapter.dispose();
+                subscribeSpy.mockRestore();
+        });
+
+        it('registers cost tracker adapter handlers when constructed', async () => {
+                const events = new PluginEvents();
+                const subscribeSpy = jest.spyOn(events, 'subscribe');
+
+                const adapter = new CostTrackerEventsAdapter(events);
+
+                expect(subscribeSpy).toHaveBeenCalledWith(
+                        'cost-tracker:updated',
+                        (adapter as unknown as { handleUpdated: unknown }).handleUpdated
+                );
+                expect(subscribeSpy).toHaveBeenCalledWith(
+                        'cost-tracker:reset',
+                        (adapter as unknown as { handleReset: unknown }).handleReset
+                );
+
+                const registeredHandler = subscribeSpy.mock.calls.find(
+                        ([event]) => event === 'cost-tracker:reset'
+                )?.[1] as (payload: unknown) => Promise<void>;
+                if (registeredHandler) {
+                        await expect(registeredHandler(undefined)).resolves.toBeUndefined();
+                }
+
+                adapter.dispose();
+                subscribeSpy.mockRestore();
+        });
+});

--- a/tests/unit/plugin-events.test.ts
+++ b/tests/unit/plugin-events.test.ts
@@ -1,115 +1,117 @@
 import {
-        PluginEvents,
-        PluginEventScope,
-        VaultIndexerEventsAdapter,
-        CostTrackerEventsAdapter,
+	PluginEvents,
+	PluginEventScope,
+	VaultIndexerEventsAdapter,
+	CostTrackerEventsAdapter,
 } from '../../src/core/events/PluginEvents';
 
 describe('PluginEvents', () => {
-        it('notifies subscribers with typed payloads', async () => {
-                const events = new PluginEvents();
-                const handler = jest.fn();
+	it('notifies subscribers with typed payloads', async () => {
+		const events = new PluginEvents();
+		const handler = jest.fn();
 
-                events.subscribe('cost-tracker:updated', handler);
-                await events.emit('cost-tracker:updated', { total: 42 });
+		events.subscribe('cost-tracker:updated', handler);
+		await events.emit('cost-tracker:updated', { total: 42 });
 
-                expect(handler).toHaveBeenCalledWith({ total: 42 });
-        });
+		expect(handler).toHaveBeenCalledWith({ total: 42 });
+	});
 
-        it('supports one-time subscriptions', async () => {
-                const events = new PluginEvents();
-                const handler = jest.fn();
+	it('supports one-time subscriptions', async () => {
+		const events = new PluginEvents();
+		const handler = jest.fn();
 
-                events.subscribeOnce('vault:indexer:updated', handler);
-                await events.emit('vault:indexer:updated', { progress: 0.5 });
-                await events.emit('vault:indexer:updated', { progress: 0.9 });
+		events.subscribeOnce('vault:indexer:updated', handler);
+		await events.emit('vault:indexer:updated', { progress: 0.5 });
+		await events.emit('vault:indexer:updated', { progress: 0.9 });
 
-                expect(handler).toHaveBeenCalledTimes(1);
-                expect(handler).toHaveBeenCalledWith({ progress: 0.5 });
-        });
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(handler).toHaveBeenCalledWith({ progress: 0.5 });
+	});
 
-        it('clears subscriptions via scopes and clearAll', async () => {
-                const events = new PluginEvents();
-                const scope = new PluginEventScope(events);
-                const handler = jest.fn();
+	it('clears subscriptions via scopes and clearAll', async () => {
+		const events = new PluginEvents();
+		const scope = new PluginEventScope(events);
+		const handler = jest.fn();
 
-                scope.on('plugin:initialized', handler);
-                await events.emit('plugin:initialized');
-                expect(handler).toHaveBeenCalledTimes(1);
+		scope.on('plugin:initialized', handler);
+		await events.emit('plugin:initialized');
+		expect(handler).toHaveBeenCalledTimes(1);
 
-                scope.dispose();
-                await events.emit('plugin:initialized');
-                expect(handler).toHaveBeenCalledTimes(1);
+		scope.dispose();
+		await events.emit('plugin:initialized');
+		expect(handler).toHaveBeenCalledTimes(1);
 
-                const anotherHandler = jest.fn();
-                events.subscribe('cost-tracker:reset', anotherHandler);
-                events.clearAll();
-                await events.emit('cost-tracker:reset');
-                expect(anotherHandler).not.toHaveBeenCalled();
-        });
+		const anotherHandler = jest.fn();
+		events.subscribe('cost-tracker:reset', anotherHandler);
+		events.clearAll();
+		await events.emit('cost-tracker:reset');
+		expect(anotherHandler).not.toHaveBeenCalled();
+	});
 
-        it('removes scoped subscriptions when manually unsubscribed', async () => {
-                const events = new PluginEvents();
-                const scope = new PluginEventScope(events);
-                const handler = jest.fn();
+	it('removes scoped subscriptions when manually unsubscribed', async () => {
+		const events = new PluginEvents();
+		const scope = new PluginEventScope(events);
+		const handler = jest.fn();
 
-                const subscription = scope.on('cost-tracker:reset', handler);
-                subscription.unsubscribe();
+		const subscription = scope.on('cost-tracker:reset', handler);
+		subscription.unsubscribe();
 
-                await events.emit('cost-tracker:reset');
+		await events.emit('cost-tracker:reset');
 
-                expect(handler).not.toHaveBeenCalled();
+		expect(handler).not.toHaveBeenCalled();
 
-                scope.dispose();
-        });
+		scope.dispose();
+	});
 });
 
 describe('Plugin event adapters', () => {
-        it('registers vault indexer adapter handlers when constructed', async () => {
-                const events = new PluginEvents();
-                const subscribeSpy = jest.spyOn(events, 'subscribe');
+	it('registers vault indexer adapter handlers when constructed', async () => {
+		const events = new PluginEvents();
+		const subscribeSpy = jest.spyOn(events, 'subscribe');
 
-                const adapter = new VaultIndexerEventsAdapter(events);
+		const adapter = new VaultIndexerEventsAdapter(events);
 
-                expect(subscribeSpy).toHaveBeenCalledWith(
-                        'vault:indexer:initialized',
-                        (adapter as unknown as { handleInitialized: unknown }).handleInitialized
-                );
-                expect(subscribeSpy).toHaveBeenCalledWith(
-                        'vault:indexer:updated',
-                        (adapter as unknown as { handleUpdated: unknown }).handleUpdated
-                );
+		expect(subscribeSpy).toHaveBeenCalledWith(
+			'vault:indexer:initialized',
+			(adapter as unknown as { handleInitialized: unknown }).handleInitialized
+		);
+		expect(subscribeSpy).toHaveBeenCalledWith(
+			'vault:indexer:updated',
+			(adapter as unknown as { handleUpdated: unknown }).handleUpdated
+		);
 
-                const registeredHandler = subscribeSpy.mock.calls[0][1] as (payload: unknown) => Promise<void>;
-                await expect(registeredHandler({ timestamp: Date.now() })).resolves.toBeUndefined();
+		const registeredHandler = subscribeSpy.mock.calls[0][1] as (
+			payload: unknown
+		) => Promise<void>;
+		await expect(registeredHandler({ timestamp: Date.now() })).resolves.toBeUndefined();
 
-                adapter.dispose();
-                subscribeSpy.mockRestore();
-        });
+		adapter.dispose();
+		subscribeSpy.mockRestore();
+	});
 
-        it('registers cost tracker adapter handlers when constructed', async () => {
-                const events = new PluginEvents();
-                const subscribeSpy = jest.spyOn(events, 'subscribe');
+	it('registers cost tracker adapter handlers when constructed', async () => {
+		const events = new PluginEvents();
+		const subscribeSpy = jest.spyOn(events, 'subscribe');
 
-                const adapter = new CostTrackerEventsAdapter(events);
+		const adapter = new CostTrackerEventsAdapter(events);
 
-                expect(subscribeSpy).toHaveBeenCalledWith(
-                        'cost-tracker:updated',
-                        (adapter as unknown as { handleUpdated: unknown }).handleUpdated
-                );
-                expect(subscribeSpy).toHaveBeenCalledWith(
-                        'cost-tracker:reset',
-                        (adapter as unknown as { handleReset: unknown }).handleReset
-                );
+		expect(subscribeSpy).toHaveBeenCalledWith(
+			'cost-tracker:updated',
+			(adapter as unknown as { handleUpdated: unknown }).handleUpdated
+		);
+		expect(subscribeSpy).toHaveBeenCalledWith(
+			'cost-tracker:reset',
+			(adapter as unknown as { handleReset: unknown }).handleReset
+		);
 
-                const registeredHandler = subscribeSpy.mock.calls.find(
-                        ([event]) => event === 'cost-tracker:reset'
-                )?.[1] as (payload: unknown) => Promise<void>;
-                if (registeredHandler) {
-                        await expect(registeredHandler(undefined)).resolves.toBeUndefined();
-                }
+		const registeredHandler = subscribeSpy.mock.calls.find(
+			([event]) => event === 'cost-tracker:reset'
+		)?.[1] as (payload: unknown) => Promise<void>;
+		if (registeredHandler) {
+			await expect(registeredHandler(undefined)).resolves.toBeUndefined();
+		}
 
-                adapter.dispose();
-                subscribeSpy.mockRestore();
-        });
+		adapter.dispose();
+		subscribeSpy.mockRestore();
+	});
 });

--- a/tests/unit/service-container.test.ts
+++ b/tests/unit/service-container.test.ts
@@ -81,6 +81,6 @@ describe('ServiceContainer', () => {
                 const scope = container.createScope();
                 await scope.reloadSettings(DEFAULT_SETTINGS);
 
-                expect(reloadHook).toHaveBeenCalledWith(DEFAULT_SETTINGS, scope);
+                expect(reloadHook).toHaveBeenCalledWith(DEFAULT_SETTINGS, container);
         });
 });

--- a/tests/unit/service-container.test.ts
+++ b/tests/unit/service-container.test.ts
@@ -2,85 +2,85 @@ import { ServiceContainer } from '../../src/core/di/ServiceContainer';
 import { DEFAULT_SETTINGS, GranolaSettings } from '../../src/types';
 
 describe('ServiceContainer', () => {
-        it('resolves singleton registrations once', async () => {
-                const container = new ServiceContainer();
-                let createCount = 0;
+	it('resolves singleton registrations once', async () => {
+		const container = new ServiceContainer();
+		let createCount = 0;
 
-                container.registerSingleton('singleton-test', () => {
-                        createCount += 1;
-                        return { created: createCount };
-                });
+		container.registerSingleton('singleton-test', () => {
+			createCount += 1;
+			return { created: createCount };
+		});
 
-                const first = await container.resolve('singleton-test');
-                const second = await container.resolve('singleton-test');
+		const first = await container.resolve('singleton-test');
+		const second = await container.resolve('singleton-test');
 
-                expect(first).toBe(second);
-                expect(createCount).toBe(1);
-        });
+		expect(first).toBe(second);
+		expect(createCount).toBe(1);
+	});
 
-        it('provides scoped instances per scope', async () => {
-                const container = new ServiceContainer();
+	it('provides scoped instances per scope', async () => {
+		const container = new ServiceContainer();
 
-                container.registerScoped('scoped-test', () => ({ id: Symbol('scoped') }));
+		container.registerScoped('scoped-test', () => ({ id: Symbol('scoped') }));
 
-                const scopeA = container.createScope();
-                const scopeB = container.createScope();
+		const scopeA = container.createScope();
+		const scopeB = container.createScope();
 
-                const firstScopeInstance = await scopeA.resolve('scoped-test');
-                const secondScopeInstance = await scopeA.resolve('scoped-test');
-                const otherScopeInstance = await scopeB.resolve('scoped-test');
+		const firstScopeInstance = await scopeA.resolve('scoped-test');
+		const secondScopeInstance = await scopeA.resolve('scoped-test');
+		const otherScopeInstance = await scopeB.resolve('scoped-test');
 
-                expect(firstScopeInstance).toBe(secondScopeInstance);
-                expect(firstScopeInstance).not.toBe(otherScopeInstance);
-        });
+		expect(firstScopeInstance).toBe(secondScopeInstance);
+		expect(firstScopeInstance).not.toBe(otherScopeInstance);
+	});
 
-        it('supports asynchronous factories', async () => {
-                const container = new ServiceContainer();
+	it('supports asynchronous factories', async () => {
+		const container = new ServiceContainer();
 
-                container.registerSingleton('async-test', async () => {
-                        await new Promise((resolve) => setTimeout(resolve, 0));
-                        return { ready: true };
-                });
+		container.registerSingleton('async-test', async () => {
+			await new Promise(resolve => setTimeout(resolve, 0));
+			return { ready: true };
+		});
 
-                const instance = await container.resolve('async-test');
-                expect(instance).toEqual({ ready: true });
-        });
+		const instance = await container.resolve('async-test');
+		expect(instance).toEqual({ ready: true });
+	});
 
-        it('invokes settings reload hooks for registrations', async () => {
-                const container = new ServiceContainer();
-                const reloadHook = jest.fn();
+	it('invokes settings reload hooks for registrations', async () => {
+		const container = new ServiceContainer();
+		const reloadHook = jest.fn();
 
-                container.registerSingleton('settings-aware', () => ({}), {
-                        onSettingsReload: reloadHook,
-                });
+		container.registerSingleton('settings-aware', () => ({}), {
+			onSettingsReload: reloadHook,
+		});
 
-                const newSettings: GranolaSettings = {
-                        ...DEFAULT_SETTINGS,
-                        plugin: {
-                                ...DEFAULT_SETTINGS.plugin,
-                                flags: {
-                                        ...DEFAULT_SETTINGS.plugin.flags,
-                                        useEventBus: true,
-                                },
-                        },
-                };
+		const newSettings: GranolaSettings = {
+			...DEFAULT_SETTINGS,
+			plugin: {
+				...DEFAULT_SETTINGS.plugin,
+				flags: {
+					...DEFAULT_SETTINGS.plugin.flags,
+					useEventBus: true,
+				},
+			},
+		};
 
-                await container.reloadSettings(newSettings);
+		await container.reloadSettings(newSettings);
 
-                expect(reloadHook).toHaveBeenCalledWith(newSettings, container);
-        });
+		expect(reloadHook).toHaveBeenCalledWith(newSettings, container);
+	});
 
-        it('propagates reload hooks through scoped containers', async () => {
-                const container = new ServiceContainer();
-                const reloadHook = jest.fn();
+	it('propagates reload hooks through scoped containers', async () => {
+		const container = new ServiceContainer();
+		const reloadHook = jest.fn();
 
-                container.registerScoped('scoped-settings', () => ({}), {
-                        onSettingsReload: reloadHook,
-                });
+		container.registerScoped('scoped-settings', () => ({}), {
+			onSettingsReload: reloadHook,
+		});
 
-                const scope = container.createScope();
-                await scope.reloadSettings(DEFAULT_SETTINGS);
+		const scope = container.createScope();
+		await scope.reloadSettings(DEFAULT_SETTINGS);
 
-                expect(reloadHook).toHaveBeenCalledWith(DEFAULT_SETTINGS, container);
-        });
+		expect(reloadHook).toHaveBeenCalledWith(DEFAULT_SETTINGS, container);
+	});
 });

--- a/tests/unit/service-container.test.ts
+++ b/tests/unit/service-container.test.ts
@@ -1,0 +1,86 @@
+import { ServiceContainer } from '../../src/core/di/ServiceContainer';
+import { DEFAULT_SETTINGS, GranolaSettings } from '../../src/types';
+
+describe('ServiceContainer', () => {
+        it('resolves singleton registrations once', async () => {
+                const container = new ServiceContainer();
+                let createCount = 0;
+
+                container.registerSingleton('singleton-test', () => {
+                        createCount += 1;
+                        return { created: createCount };
+                });
+
+                const first = await container.resolve('singleton-test');
+                const second = await container.resolve('singleton-test');
+
+                expect(first).toBe(second);
+                expect(createCount).toBe(1);
+        });
+
+        it('provides scoped instances per scope', async () => {
+                const container = new ServiceContainer();
+
+                container.registerScoped('scoped-test', () => ({ id: Symbol('scoped') }));
+
+                const scopeA = container.createScope();
+                const scopeB = container.createScope();
+
+                const firstScopeInstance = await scopeA.resolve('scoped-test');
+                const secondScopeInstance = await scopeA.resolve('scoped-test');
+                const otherScopeInstance = await scopeB.resolve('scoped-test');
+
+                expect(firstScopeInstance).toBe(secondScopeInstance);
+                expect(firstScopeInstance).not.toBe(otherScopeInstance);
+        });
+
+        it('supports asynchronous factories', async () => {
+                const container = new ServiceContainer();
+
+                container.registerSingleton('async-test', async () => {
+                        await new Promise((resolve) => setTimeout(resolve, 0));
+                        return { ready: true };
+                });
+
+                const instance = await container.resolve('async-test');
+                expect(instance).toEqual({ ready: true });
+        });
+
+        it('invokes settings reload hooks for registrations', async () => {
+                const container = new ServiceContainer();
+                const reloadHook = jest.fn();
+
+                container.registerSingleton('settings-aware', () => ({}), {
+                        onSettingsReload: reloadHook,
+                });
+
+                const newSettings: GranolaSettings = {
+                        ...DEFAULT_SETTINGS,
+                        plugin: {
+                                ...DEFAULT_SETTINGS.plugin,
+                                flags: {
+                                        ...DEFAULT_SETTINGS.plugin.flags,
+                                        useEventBus: true,
+                                },
+                        },
+                };
+
+                await container.reloadSettings(newSettings);
+
+                expect(reloadHook).toHaveBeenCalledWith(newSettings, container);
+        });
+
+        it('propagates reload hooks through scoped containers', async () => {
+                const container = new ServiceContainer();
+                const reloadHook = jest.fn();
+
+                container.registerScoped('scoped-settings', () => ({}), {
+                        onSettingsReload: reloadHook,
+                });
+
+                const scope = container.createScope();
+                await scope.reloadSettings(DEFAULT_SETTINGS);
+
+                expect(reloadHook).toHaveBeenCalledWith(DEFAULT_SETTINGS, scope);
+        });
+});

--- a/tests/unit/service-container.test.ts
+++ b/tests/unit/service-container.test.ts
@@ -34,6 +34,29 @@ describe('ServiceContainer', () => {
 		expect(firstScopeInstance).not.toBe(otherScopeInstance);
 	});
 
+	it('resolves singletons with the registration container instead of the requesting scope', async () => {
+		const container = new ServiceContainer();
+
+		container.registerScoped('scoped-dependency', () => ({ scopeId: Symbol('scope') }));
+		container.registerSingleton('singleton-with-scope', async resolver => ({
+			dependency: await resolver.resolve('scoped-dependency'),
+			resolver,
+		}));
+
+		const scopeA = container.createScope();
+		const scopeB = container.createScope();
+
+		const singletonFromScopeA = await scopeA.resolve('singleton-with-scope');
+		const singletonFromScopeB = await scopeB.resolve('singleton-with-scope');
+		const rootScopedDependency = await container.resolve('scoped-dependency');
+		const scopeScopedDependency = await scopeA.resolve('scoped-dependency');
+
+		expect(singletonFromScopeA).toBe(singletonFromScopeB);
+		expect(singletonFromScopeA.resolver).toBe(container);
+		expect(singletonFromScopeA.dependency).toBe(rootScopedDependency);
+		expect(singletonFromScopeA.dependency).not.toBe(scopeScopedDependency);
+	});
+
 	it('supports asynchronous factories', async () => {
 		const container = new ServiceContainer();
 


### PR DESCRIPTION
## Summary
- add a ServiceContainer to manage singleton and scoped services with settings reload hooks
- scaffold a PluginEvents bus and stub adapters for the vault indexer and cost tracker
- gate the new infrastructure behind a plugin feature flag and cover it with unit tests

## Testing
- npm test
- npm run build:check

------
https://chatgpt.com/codex/tasks/task_e_68e2a266ae6c832c84d1fb2aa202aa1e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional experimental event bus (toggle in settings) with typed event system, scoped subscriptions, and adapters for vault indexing and cost tracking; plugin emits an initialized event when enabled.
  * New lightweight dependency-injection container with singleton/scoped registrations and settings reload propagation.
* **Bug Fixes**
  * Legacy settings now preserve new plugin flag defaults; saving reloads settings into runtime components.
* **Tests**
  * Added unit tests for the event system, adapters, DI container, and settings reload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->