### PR TITLE
Protect failed import records from mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ When you run the import command, the plugin will:
    - Success/failure indicators
    - Detailed error messages if issues occur
 
+#### Recovering Failed Imports
+
+When a document can't be imported, the completion summary now helps you recover quickly:
+
+- **Retry failed imports** with a single click—only the documents that failed are retried, using the same import settings and live progress view.
+- **Export the failure list** for troubleshooting via the new dropdown:
+  - Download a CSV with document ID, title, error reason, and timestamp.
+  - Copy a formatted summary to your clipboard for sharing with support or teammates.
+- **Keep working seamlessly**—successful documents remain available to open immediately while retries and exports focus solely on the failures.
+
 ### Common Use Cases
 
 #### Daily Meeting Notes

--- a/src/services/import-manager.ts
+++ b/src/services/import-manager.ts
@@ -66,6 +66,29 @@ export interface DocumentProgress {
 }
 
 /**
+ * Record of a failed document import attempt.
+ */
+export interface FailedDocumentRecord {
+	/** Original document data */
+	document: GranolaDocument;
+
+	/** Display metadata captured at time of failure */
+	metadata?: DocumentDisplayMetadata;
+
+	/** Raw error message */
+	error: string;
+
+	/** User-friendly error description */
+	message: string;
+
+	/** Error category */
+	errorCategory?: ImportErrorCategory;
+
+	/** Timestamp of the failure */
+	timestamp: number;
+}
+
+/**
  * Overall import progress information.
  */
 export interface ImportProgress {
@@ -110,6 +133,9 @@ export interface ImportOptions {
 	/** Whether to stop on first error */
 	stopOnError: boolean;
 
+	/** Whether this import run is retrying failed documents */
+	isRetry?: boolean;
+
 	/** Custom progress callback */
 	onProgress?: (progress: ImportProgress) => void;
 
@@ -148,6 +174,9 @@ export class SelectiveImportManager {
 	private overallProgress: ImportProgress;
 	private progressCallback?: (progress: ImportProgress) => void;
 	private documentProgressCallback?: (docProgress: DocumentProgress) => void;
+	private failedDocuments: FailedDocumentRecord[] = [];
+	private lastImportMetadata: Map<string, DocumentDisplayMetadata> = new Map();
+	private lastImportOptions: ImportOptions = { ...DEFAULT_OPTIONS };
 
 	/**
 	 * Creates a new selective import manager.
@@ -193,7 +222,10 @@ export class SelectiveImportManager {
 		}
 
 		try {
-			this.startImport(selectedDocuments, options);
+			const mergedOptions: ImportOptions = { ...DEFAULT_OPTIONS, ...options };
+			this.lastImportOptions = mergedOptions;
+
+			this.startImport(selectedDocuments, mergedOptions);
 
 			// Data preparation
 			const documentMap = new Map(granolaDocuments.map(doc => [doc.id, doc]));
@@ -201,11 +233,15 @@ export class SelectiveImportManager {
 				.filter(meta => meta.selected && documentMap.has(meta.id))
 				.map(meta => ({ meta, doc: documentMap.get(meta.id)! }));
 
+			this.lastImportMetadata = new Map(
+				importQueue.map(({ meta }) => [meta.id, this.cloneMetadata(meta)])
+			);
+
 			// Update total count based on actual documents to be processed
 			this.overallProgress.total = importQueue.length;
 
 			// Document processing
-			await this.processDocumentQueue(importQueue, options);
+			await this.processDocumentQueue(importQueue, mergedOptions);
 
 			this.completeImport();
 
@@ -263,6 +299,65 @@ export class SelectiveImportManager {
 	}
 
 	/**
+	 * Gets a snapshot of failed document records from the last completed import.
+	 *
+	 * @returns {FailedDocumentRecord[]} Failed document details
+	 */
+        getFailedDocuments(): FailedDocumentRecord[] {
+                return this.failedDocuments.map(record => ({
+                        ...record,
+                        metadata: record.metadata ? this.cloneMetadata(record.metadata) : undefined,
+                        document: this.cloneDocument(record.document),
+                }));
+        }
+
+	/**
+	 * Retries importing the documents that previously failed.
+	 *
+	 * @param {ImportOptions} [options] - Import options for the retry attempt
+	 * @returns {Promise<ImportProgress>} Final results of the retry
+	 */
+	async retryFailedImports(options?: ImportOptions): Promise<ImportProgress> {
+		if (this.failedDocuments.length === 0) {
+			throw new Error('There are no failed documents to retry.');
+		}
+
+                const retryRecords = this.failedDocuments
+                        .map(record => {
+                                const metadata = record.metadata ?? this.lastImportMetadata.get(record.document.id);
+                                if (!metadata) {
+                                        return null;
+                                }
+
+                                const clonedMetadata = this.cloneMetadata(metadata);
+                                clonedMetadata.selected = true;
+
+                                return {
+                                        metadata: clonedMetadata,
+                                        document: this.cloneDocument(record.document),
+                                };
+                        })
+                        .filter((entry): entry is { metadata: DocumentDisplayMetadata; document: GranolaDocument } =>
+                                entry !== null
+                        );
+
+		if (retryRecords.length === 0) {
+			throw new Error('Unable to retry failed documents because metadata is unavailable.');
+		}
+
+		const retryMetadata = retryRecords.map(entry => entry.metadata);
+		const retryDocuments = retryRecords.map(entry => entry.document);
+
+		const retryOptions: ImportOptions = {
+			...this.lastImportOptions,
+			...(options ?? {}),
+			isRetry: true,
+		};
+
+		return this.importDocuments(retryMetadata, retryDocuments, retryOptions);
+	}
+
+	/**
 	 * Resets the import manager state.
 	 * Should be called before starting a new import.
 	 */
@@ -271,6 +366,8 @@ export class SelectiveImportManager {
 		this.isCancelled = false;
 		this.documentProgress.clear();
 		this.overallProgress = this.createInitialProgress();
+		this.failedDocuments = [];
+		this.lastImportMetadata = new Map();
 	}
 
 	/**
@@ -509,17 +606,27 @@ export class SelectiveImportManager {
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 			const errorCategory = this.categorizeError(error);
+			const friendlyMessage = this.getErrorMessage(errorCategory, errorMessage);
 
 			this.updateDocumentProgress(doc.id, {
 				status: 'failed',
 				progress: 100,
-				message: this.getErrorMessage(errorCategory, errorMessage),
+				message: friendlyMessage,
 				error: errorMessage,
 				errorCategory,
 				endTime: Date.now(),
 			});
 
 			this.overallProgress.failed++;
+
+                        this.failedDocuments.push({
+                                document: this.cloneDocument(doc),
+                                metadata: this.lastImportMetadata.get(doc.id),
+                                error: errorMessage,
+                                message: friendlyMessage,
+                                errorCategory,
+                                timestamp: Date.now(),
+                        });
 
 			if (options.stopOnError) {
 				this.cancel();
@@ -998,4 +1105,38 @@ export class SelectiveImportManager {
 				return `Import failed: ${originalMessage}`;
 		}
 	}
+
+	/**
+	 * Clones document metadata to avoid accidental external mutations.
+	 *
+	 * @private
+	 * @param {DocumentDisplayMetadata} metadata - Metadata to clone
+	 * @returns {DocumentDisplayMetadata} Cloned metadata object
+	 */
+        private cloneMetadata(metadata: DocumentDisplayMetadata): DocumentDisplayMetadata {
+                return {
+                        ...metadata,
+                        importStatus: { ...metadata.importStatus },
+                };
+        }
+
+        /**
+         * Deeply clones a Granola document to protect internal state from external mutations.
+         * Falls back to JSON serialization when structuredClone is unavailable.
+         *
+         * @private
+         * @param {GranolaDocument} document - Document to clone
+         * @returns {GranolaDocument} Cloned document
+         */
+        private cloneDocument(document: GranolaDocument): GranolaDocument {
+                const structuredCloneFn = (globalThis as typeof globalThis & {
+                        structuredClone?: <T>(value: T) => T;
+                }).structuredClone;
+
+                if (structuredCloneFn) {
+                        return structuredCloneFn(document);
+                }
+
+                return JSON.parse(JSON.stringify(document)) as GranolaDocument;
+        }
 }

--- a/src/ui/document-selection-modal.ts
+++ b/src/ui/document-selection-modal.ts
@@ -1,12 +1,13 @@
 import {
-	Modal,
-	App,
-	ButtonComponent,
-	TextComponent,
-	Notice,
-	TFile,
-	WorkspaceLeaf,
-	MarkdownView,
+        Modal,
+        App,
+        ButtonComponent,
+        TextComponent,
+        Notice,
+        TFile,
+        WorkspaceLeaf,
+        MarkdownView,
+        Menu,
 } from 'obsidian';
 import { GranolaDocument, GranolaAPI } from '../api';
 import { DuplicateDetector } from '../services/duplicate-detector';
@@ -17,11 +18,12 @@ import {
 	DocumentSort,
 } from '../services/document-metadata';
 import {
-	SelectiveImportManager,
-	ImportProgress,
-	DocumentProgress,
-	DocumentImportStatus,
-	ImportOptions,
+        SelectiveImportManager,
+        ImportProgress,
+        DocumentProgress,
+        DocumentImportStatus,
+        ImportOptions,
+        FailedDocumentRecord,
 } from '../services/import-manager';
 import { ProseMirrorConverter } from '../converter';
 
@@ -734,20 +736,21 @@ export class DocumentSelectionModal extends Modal {
 		const summary = this.progressEl.createDiv('import-summary');
 		summary.createEl('h3', { text: 'Import complete!' });
 
-		// Get all document progress for detailed reporting
-		const allDocProgress = this.importManager.getAllDocumentProgress();
+                // Get all document progress for detailed reporting
+                const allDocProgress = this.importManager.getAllDocumentProgress();
+                const failedRecords = this.importManager.getFailedDocuments();
 
-		// Create overview statistics
-		this.createOverviewStats(summary, result);
+                // Create overview statistics
+                this.createOverviewStats(summary, result);
 
-		// Create detailed sections for different outcomes
-		if (result.completed > 0) {
-			this.createSuccessSection(summary, allDocProgress);
-		}
+                // Create detailed sections for different outcomes
+                if (result.completed > 0) {
+                        this.createSuccessSection(summary, allDocProgress);
+                }
 
-		if (result.failed > 0) {
-			this.createFailureSection(summary, allDocProgress);
-		}
+                if (result.failed > 0) {
+                        this.createFailureSection(summary, allDocProgress);
+                }
 
 		if (result.skipped > 0) {
 			this.createSkippedSection(summary, allDocProgress);
@@ -766,23 +769,43 @@ export class DocumentSelectionModal extends Modal {
 			.map(progress => progress.file!)
 			.filter(file => file !== undefined);
 
-		// Add buttons for next actions
-		const buttonsDiv = summary.createDiv('import-complete-buttons');
+                // Add buttons for next actions
+                const buttonsDiv = summary.createDiv('import-complete-buttons');
 
-		// If there are imported files, show "Open Imported Notes" button
-		if (importedFiles.length > 0) {
-			new ButtonComponent(buttonsDiv)
-				.setButtonText(`Open imported notes (${importedFiles.length})`)
-				.setCta()
-				.onClick(() => {
-					this.openImportedFiles(importedFiles);
-					this.close();
-				});
-		}
+                if (failedRecords.length > 0) {
+                        new ButtonComponent(buttonsDiv)
+                                .setButtonText(`Retry failed imports (${failedRecords.length})`)
+                                .setCta()
+                                .onClick(() => {
+                                        void this.retryFailedDocuments();
+                                });
 
-		// Always show close button
-		new ButtonComponent(buttonsDiv).setButtonText('Close').onClick(() => this.close());
-	}
+                        new ButtonComponent(buttonsDiv)
+                                .setButtonText('Export failed list')
+                                .onClick((event: MouseEvent) => {
+                                        this.showFailedExportMenu(event);
+                                });
+                }
+
+                // If there are imported files, show "Open Imported Notes" button
+                if (importedFiles.length > 0) {
+                        const openButton = new ButtonComponent(buttonsDiv).setButtonText(
+                                `Open imported notes (${importedFiles.length})`
+                        );
+
+                        if (failedRecords.length === 0) {
+                                openButton.setCta();
+                        }
+
+                        openButton.onClick(() => {
+                                this.openImportedFiles(importedFiles);
+                                this.close();
+                        });
+                }
+
+                // Always show close button
+                new ButtonComponent(buttonsDiv).setButtonText('Close').onClick(() => this.close());
+        }
 
 	/**
 	 * Creates overview statistics section.
@@ -873,11 +896,11 @@ export class DocumentSelectionModal extends Modal {
 	 * @param {HTMLElement} container - Container element
 	 * @param {DocumentProgress[]} allDocProgress - All document progress data
 	 */
-	private createFailureSection(container: HTMLElement, allDocProgress: DocumentProgress[]): void {
-		const failedDocs = allDocProgress.filter(progress => progress.status === 'failed');
-		if (failedDocs.length === 0) return;
+        private createFailureSection(container: HTMLElement, allDocProgress: DocumentProgress[]): void {
+                const failedDocs = allDocProgress.filter(progress => progress.status === 'failed');
+                if (failedDocs.length === 0) return;
 
-		const section = container.createDiv('import-section failure-section');
+                const section = container.createDiv('import-section failure-section');
 		const header = section.createDiv('section-header');
 		header.createEl('h4', { text: `❌ Failed documents (${failedDocs.length})` });
 
@@ -913,8 +936,231 @@ export class DocumentSelectionModal extends Modal {
 			});
 		});
 
-		this.setupSectionToggle(toggle, content);
-	}
+                this.setupSectionToggle(toggle, content);
+        }
+
+        /**
+         * Retries documents that failed during the last import attempt.
+         *
+         * @private
+         * @async
+         */
+        private async retryFailedDocuments(): Promise<void> {
+                const failedRecords = this.importManager.getFailedDocuments();
+                if (failedRecords.length === 0) {
+                        new Notice('There are no failed documents to retry.');
+                        return;
+                }
+
+                // Highlight failed documents in metadata for consistency with progress view
+                const failedIds = new Set(failedRecords.map(record => record.document.id));
+                this.documentMetadata = this.documentMetadata.map(meta => ({
+                        ...meta,
+                        selected: failedIds.has(meta.id),
+                }));
+
+                try {
+                        this.setImporting(true);
+                        this.showProgressView();
+
+                        const retryOptions: ImportOptions = {
+                                strategy: 'skip',
+                                stopOnError: false,
+                                onProgress: progress => this.updateProgress(progress),
+                                onDocumentProgress: docProgress => this.updateDocumentProgress(docProgress),
+                                isRetry: true,
+                        };
+
+                        const result = await this.importManager.retryFailedImports(retryOptions);
+                        this.showImportComplete(result);
+                } catch (error) {
+                        console.error('[Granola Importer] Retry failed imports error:', error);
+                        const message = error instanceof Error ? error.message : 'Unknown error';
+                        new Notice(`Retry failed: ${message}`, 5000);
+                        this.showImportComplete(this.importManager.getProgress());
+                } finally {
+                        this.setImporting(false);
+                }
+        }
+
+        /**
+         * Shows export options for failed documents.
+         *
+         * @private
+         * @param {MouseEvent} event - Click event for positioning the menu
+         */
+        private showFailedExportMenu(event: MouseEvent): void {
+                const failedRecords = this.importManager.getFailedDocuments();
+                if (failedRecords.length === 0) {
+                        new Notice('There are no failed documents to export.');
+                        return;
+                }
+
+                const menu = new Menu();
+                menu.addItem(item =>
+                        item.setTitle('Download CSV').onClick(() => {
+                                this.exportFailedDocumentsAsCSV(failedRecords);
+                        })
+                );
+
+                menu.addItem(item =>
+                        item.setTitle('Copy summary to clipboard').onClick(() => {
+                                void this.copyFailedDocumentsToClipboard(failedRecords);
+                        })
+                );
+
+                menu.showAtMouseEvent(event);
+        }
+
+        /**
+         * Exports failed document details as a CSV file for troubleshooting.
+         *
+         * @private
+         * @param {FailedDocumentRecord[]} records - Failed document records
+         */
+        private exportFailedDocumentsAsCSV(records: FailedDocumentRecord[]): void {
+                if (records.length === 0) {
+                        new Notice('There are no failed documents to export.');
+                        return;
+                }
+
+                const csvContent = this.buildFailedDocumentsCsv(records);
+                const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+                const url = URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                link.href = url;
+                link.download = `granola-failed-imports-${new Date().toISOString()}.csv`;
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                URL.revokeObjectURL(url);
+
+                new Notice('Failed import list exported as CSV.');
+        }
+
+        /**
+         * Copies a formatted summary of failed documents to the clipboard.
+         *
+         * @private
+         * @param {FailedDocumentRecord[]} records - Failed document records
+         */
+        private async copyFailedDocumentsToClipboard(records: FailedDocumentRecord[]): Promise<void> {
+                if (records.length === 0) {
+                        new Notice('There are no failed documents to copy.');
+                        return;
+                }
+
+                const summary = this.buildFailedDocumentsSummary(records);
+
+                try {
+                        if (navigator?.clipboard?.writeText) {
+                                await navigator.clipboard.writeText(summary);
+                        } else {
+                                const textarea = document.createElement('textarea');
+                                textarea.value = summary;
+                                textarea.style.position = 'fixed';
+                                textarea.style.opacity = '0';
+                                document.body.appendChild(textarea);
+                                textarea.focus();
+                                textarea.select();
+                                document.execCommand('copy');
+                                document.body.removeChild(textarea);
+                        }
+
+                        new Notice('Failed import summary copied to clipboard.');
+                } catch (error) {
+                        console.error('[Granola Importer] Clipboard copy failed:', error);
+                        new Notice('Unable to copy failed import summary to clipboard.', 5000);
+                }
+        }
+
+        /**
+         * Builds CSV content for failed document records.
+         *
+         * @private
+         * @param {FailedDocumentRecord[]} records - Failed document records
+         * @returns {string} CSV formatted string
+         */
+        private buildFailedDocumentsCsv(records: FailedDocumentRecord[]): string {
+                const header = '"Document ID","Title","Error Reason","Failed At"';
+                const rows = records.map(record => {
+                        const id = this.csvEscape(record.document.id);
+                        const title = this.csvEscape(this.getFailedDocumentTitle(record));
+                        const reason = this.csvEscape(record.message || record.error || 'Unknown error');
+                        const failedAt = this.csvEscape(this.formatFailureTimestamp(record.timestamp));
+                        return `"${id}","${title}","${reason}","${failedAt}"`;
+                });
+
+                return [header, ...rows].join('\n');
+        }
+
+        /**
+         * Builds a troubleshooting-friendly summary for failed documents.
+         *
+         * @private
+         * @param {FailedDocumentRecord[]} records - Failed document records
+         * @returns {string} Summary text for clipboard export
+         */
+        private buildFailedDocumentsSummary(records: FailedDocumentRecord[]): string {
+                const lines: string[] = [];
+                lines.push('Granola Failed Import Summary');
+                lines.push(`Generated: ${new Date().toISOString()}`);
+                lines.push(`Total failed documents: ${records.length}`);
+                lines.push('');
+
+                records.forEach(record => {
+                        const title = this.getFailedDocumentTitle(record);
+                        const reason = record.message || record.error || 'Unknown error';
+                        const failedAt = this.formatFailureTimestamp(record.timestamp);
+                        lines.push(`• ${title}`);
+                        lines.push(`  ID: ${record.document.id}`);
+                        lines.push(`  Reason: ${reason}`);
+                        lines.push(`  Failed at: ${failedAt}`);
+                        lines.push('');
+                });
+
+                return lines.join('\n');
+        }
+
+        /**
+         * Escapes values for safe inclusion in CSV content.
+         *
+         * @private
+         * @param {string} value - Value to escape
+         * @returns {string} Escaped value
+         */
+        private csvEscape(value: string): string {
+                return value.replace(/"/g, '""');
+        }
+
+        /**
+         * Gets a user-friendly title for a failed document record.
+         *
+         * @private
+         * @param {FailedDocumentRecord} record - Failed document record
+         * @returns {string} Document title
+         */
+        private getFailedDocumentTitle(record: FailedDocumentRecord): string {
+                return record.metadata?.title || record.document.title || 'Unknown Document';
+        }
+
+        /**
+         * Formats the failure timestamp consistently.
+         *
+         * @private
+         * @param {number} timestamp - Failure timestamp (ms since epoch)
+         * @returns {string} ISO formatted timestamp or placeholder
+         */
+        private formatFailureTimestamp(timestamp: number): string {
+                if (!Number.isFinite(timestamp)) {
+                        return 'Unknown';
+                }
+                try {
+                        return new Date(timestamp).toISOString();
+                } catch (error) {
+                        return 'Unknown';
+                }
+        }
 
 	/**
 	 * Creates skipped section with categorized reasons.

--- a/tests/unit/document-selection-modal.test.ts
+++ b/tests/unit/document-selection-modal.test.ts
@@ -38,10 +38,13 @@ const mockMetadataService = {
 } as unknown as DocumentMetadataService;
 
 const mockImportManager = {
-	importDocuments: jest.fn(),
-	cancel: jest.fn(),
-	reset: jest.fn(),
-	getProgress: jest.fn(),
+        importDocuments: jest.fn(),
+        cancel: jest.fn(),
+        reset: jest.fn(),
+        getProgress: jest.fn(),
+        getAllDocumentProgress: jest.fn().mockReturnValue([]),
+        getFailedDocuments: jest.fn().mockReturnValue([]),
+        retryFailedImports: jest.fn(),
 } as unknown as SelectiveImportManager;
 
 const mockConverter = {
@@ -66,11 +69,11 @@ const mockElement = {
 
 // Mock Modal class
 jest.mock('obsidian', () => ({
-	Modal: class MockModal {
-		app: App;
-		contentEl: any;
-		titleEl: any;
-		modalEl: any;
+        Modal: class MockModal {
+                app: App;
+                contentEl: any;
+                titleEl: any;
+                modalEl: any;
 
 		constructor(app: App) {
 			this.app = app;
@@ -85,11 +88,11 @@ jest.mock('obsidian', () => ({
 
 		close() {
 			return this;
-		}
-	},
-	ButtonComponent: class MockButtonComponent {
-		constructor(public container: any) {}
-		setButtonText(text: string) {
+                }
+        },
+        ButtonComponent: class MockButtonComponent {
+                constructor(public container: any) {}
+                setButtonText(text: string) {
 			return this;
 		}
 		setCta() {
@@ -116,8 +119,19 @@ jest.mock('obsidian', () => ({
 		onChange(callback: (value: string) => void) {
 			return this;
 		}
-	},
-	Notice: jest.fn(),
+        },
+        Notice: jest.fn(),
+        Menu: class MockMenu {
+                addItem(callback: (item: any) => void) {
+                        const item = {
+                                setTitle: jest.fn().mockReturnThis(),
+                                onClick: jest.fn().mockReturnThis(),
+                        };
+                        callback(item);
+                        return this;
+                }
+                showAtMouseEvent = jest.fn();
+        },
 }));
 
 describe('DocumentSelectionModal', () => {

--- a/tests/unit/import-manager.test.ts
+++ b/tests/unit/import-manager.test.ts
@@ -578,8 +578,8 @@ describe('SelectiveImportManager', () => {
 
 	// Removed backup creation tests as createBackups option was removed
 
-	describe('edge cases and error recovery', () => {
-		it('should handle errors in handleImportError method', async () => {
+        describe('edge cases and error recovery', () => {
+                it('should handle errors in handleImportError method', async () => {
 			// Mock conversion to throw an error to trigger handleImportError
 			(mockConverter.convertDocument as jest.Mock).mockImplementationOnce(() => {
 				throw new Error('Critical conversion error');
@@ -864,8 +864,137 @@ describe('SelectiveImportManager', () => {
 			// The document should either be completed (if conflict resolution succeeds) or skipped
 			expect(result.completed + result.skipped).toBe(1);
 			expect(result.failed).toBe(0);
-		});
-	});
+                });
+        });
+
+        describe('failed import recovery features', () => {
+                it('tracks failed documents with metadata and error details', async () => {
+                        (mockConverter.convertDocument as jest.Mock).mockImplementation(doc => {
+                                if (doc.id === 'doc1') {
+                                        throw new Error('Conversion failed for doc1');
+                                }
+
+                                return {
+                                        filename: `${doc.id}.md`,
+                                        content: '# Markdown content',
+                                        frontmatter: { granola_id: doc.id, title: doc.title },
+                                        isTrulyEmpty: false,
+                                };
+                        });
+
+                        await importManager.importDocuments(mockDocumentMetadata, mockGranolaDocuments, {
+                                ...defaultOptions,
+                                stopOnError: false,
+                        });
+
+                        const failedRecords = importManager.getFailedDocuments();
+                        expect(failedRecords).toHaveLength(1);
+                        const failedRecord = failedRecords[0];
+                        expect(failedRecord.document.id).toBe('doc1');
+                        expect(failedRecord.metadata?.id).toBe('doc1');
+                        expect(failedRecord.metadata?.title).toBe('Document 1');
+                        expect(failedRecord.error).toContain('Conversion failed');
+                        expect(failedRecord.message).toContain('failed');
+                        expect(typeof failedRecord.timestamp).toBe('number');
+                });
+
+                it('returns cloned failed documents to prevent external mutation', async () => {
+                        let shouldFailDoc1 = true;
+                        (mockConverter.convertDocument as jest.Mock).mockImplementation(doc => {
+                                if (doc.id === 'doc1' && shouldFailDoc1) {
+                                        shouldFailDoc1 = false;
+                                        throw new Error('Initial failure for doc1');
+                                }
+
+                                return {
+                                        filename: `${doc.id}.md`,
+                                        content: '# Markdown content',
+                                        frontmatter: { granola_id: doc.id, title: doc.title },
+                                        isTrulyEmpty: false,
+                                };
+                        });
+
+                        await importManager.importDocuments(mockDocumentMetadata, mockGranolaDocuments, {
+                                ...defaultOptions,
+                                stopOnError: false,
+                        });
+
+                        const failedSnapshot = importManager.getFailedDocuments();
+                        expect(failedSnapshot).toHaveLength(1);
+
+                        // Mutate the returned snapshot to ensure internal state is protected
+                        failedSnapshot[0].document.title = 'Mutated title';
+                        if (failedSnapshot[0].metadata) {
+                                failedSnapshot[0].metadata.title = 'Mutated metadata title';
+                        }
+
+                        const secondSnapshot = importManager.getFailedDocuments();
+                        expect(secondSnapshot[0].document.title).toBe('Document 1');
+                        expect(secondSnapshot[0].metadata?.title).toBe('Document 1');
+                        expect(mockGranolaDocuments[0].title).toBe('Document 1');
+
+                        const retryResult = await importManager.retryFailedImports({ ...defaultOptions });
+                        expect(retryResult.failed).toBe(0);
+                });
+
+                it('retries only failed documents using stored context', async () => {
+                        let shouldFailDoc1 = true;
+                        (mockConverter.convertDocument as jest.Mock).mockImplementation(doc => {
+                                if (doc.id === 'doc1' && shouldFailDoc1) {
+                                        shouldFailDoc1 = false;
+                                        throw new Error('Initial failure for doc1');
+                                }
+
+                                return {
+                                        filename: `${doc.id}.md`,
+                                        content: '# Markdown content',
+                                        frontmatter: { granola_id: doc.id, title: doc.title },
+                                        isTrulyEmpty: false,
+                                };
+                        });
+
+                        await importManager.importDocuments(mockDocumentMetadata, mockGranolaDocuments, {
+                                ...defaultOptions,
+                                stopOnError: false,
+                        });
+
+                        const failedRecords = importManager.getFailedDocuments();
+                        expect(failedRecords).toHaveLength(1);
+                        const initialCreateCalls = (mockVault.create as jest.Mock).mock.calls.length;
+
+                        const retryProgressUpdates: ImportProgress[] = [];
+                        const retryDocumentUpdates: DocumentProgress[] = [];
+
+                        const retryResult = await importManager.retryFailedImports({
+                                ...defaultOptions,
+                                onProgress: progress => retryProgressUpdates.push(progress),
+                                onDocumentProgress: docProgress => retryDocumentUpdates.push(docProgress),
+                        });
+
+                        expect(retryResult.total).toBe(1);
+                        expect(retryResult.failed).toBe(0);
+                        expect(retryResult.completed).toBe(1);
+                        expect(importManager.getFailedDocuments()).toHaveLength(0);
+                        expect((mockVault.create as jest.Mock).mock.calls.length).toBe(initialCreateCalls + 1);
+                        expect(retryProgressUpdates.length).toBeGreaterThan(0);
+                        expect(
+                                retryDocumentUpdates.some(
+                                        update => update.id === 'doc1' && update.status === 'completed'
+                                )
+                        ).toBe(true);
+                });
+
+                it('throws when retrying without failed documents', async () => {
+                        await importManager.importDocuments(mockDocumentMetadata, mockGranolaDocuments, {
+                                ...defaultOptions,
+                                stopOnError: false,
+                        });
+
+                        await expect(
+                                importManager.retryFailedImports({ ...defaultOptions })
+                        ).rejects.toThrow('There are no failed documents to retry.');
+                });
+        });
 
 	describe('empty document filtering', () => {
 		it('should skip empty documents when setting is enabled', async () => {


### PR DESCRIPTION
## Summary
- ensure failed import records return deep-cloned documents before reuse
- clone documents when recording failures and when scheduling retry attempts
- cover the clone behavior with a regression test for `retryFailedImports`

## Testing
- npm test -- --runInBand
- npm run lint
- npm run type-check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1e4c7486c832caab01aaa7bf53176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Retry only failed imports with one click, using your previous settings and live progress.
  - Export failed items to CSV or copy a formatted summary (includes title, reason, and timestamp).
  - Enhanced completion screen highlights failed, completed, skipped, and empty results.
  - Continue using successfully imported documents while managing failures separately.

- Documentation
  - Added “Recovering Failed Imports” guide covering retries, exports, and concurrent workflow.

- Tests
  - Expanded test coverage for failure handling, retries, conflicts, and progress reporting to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->