### PR TITLE
Implement PR feedback from community submission: convert settings tab headings to sentence case

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,7 +39,7 @@ export class GranolaSettingTab extends PluginSettingTab {
 	private addConnectionSection(): void {
 		const { containerEl } = this;
 
-		new Setting(containerEl).setHeading().setName('Connection & Validation');
+		new Setting(containerEl).setHeading().setName('Connection & validation');
 
 		// Connection status
 		const statusEl = containerEl.createDiv('connection-status');
@@ -65,7 +65,7 @@ export class GranolaSettingTab extends PluginSettingTab {
 	private addDebugSection(): void {
 		const { containerEl } = this;
 
-		new Setting(containerEl).setHeading().setName('Debug & Logging');
+		new Setting(containerEl).setHeading().setName('Debug & logging');
 
 		// Debug mode toggle
 		new Setting(containerEl)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -118,7 +118,7 @@ export class GranolaSettingTab extends PluginSettingTab {
 	private addImportSection(): void {
 		const { containerEl } = this;
 
-		new Setting(containerEl).setHeading().setName('Import Behavior');
+		new Setting(containerEl).setHeading().setName('Import behavior');
 
 		// Default import strategy
 		new Setting(containerEl)
@@ -173,7 +173,7 @@ export class GranolaSettingTab extends PluginSettingTab {
 	private addContentSection(): void {
 		const { containerEl } = this;
 
-		new Setting(containerEl).setHeading().setName('Content Processing');
+		new Setting(containerEl).setHeading().setName('Content processing');
 
 		// Enhanced frontmatter toggle
 		new Setting(containerEl)
@@ -279,7 +279,7 @@ export class GranolaSettingTab extends PluginSettingTab {
 		}
 
 		// Action items section header
-		new Setting(containerEl).setHeading().setName('Action Items Processing');
+		new Setting(containerEl).setHeading().setName('Action items processing');
 
 		// Convert action items to tasks
 		new Setting(containerEl)
@@ -341,7 +341,7 @@ export class GranolaSettingTab extends PluginSettingTab {
 	private addUISection(): void {
 		const { containerEl } = this;
 
-		new Setting(containerEl).setHeading().setName('User Interface');
+		new Setting(containerEl).setHeading().setName('User interface');
 
 		// Progress notifications
 		new Setting(containerEl)
@@ -357,7 +357,7 @@ export class GranolaSettingTab extends PluginSettingTab {
 			});
 
 		// Attendee Tags section
-		new Setting(containerEl).setHeading().setName('Attendee Tags');
+		new Setting(containerEl).setHeading().setName('Attendee tags');
 
 		// Enable attendee tags
 		new Setting(containerEl)


### PR DESCRIPTION
Addresses PR review feedback from joethei (comment #3434066247). Changes all settings tab headings from title case to sentence case to comply with Obsidian's UI text conventions.

Changed headings:
- 'Import Behavior' → 'Import behavior'
- 'Content Processing' → 'Content processing'
- 'Action Items Processing' → 'Action items processing'
- 'User Interface' → 'User interface'
- 'Attendee Tags' → 'Attendee tags'

All tests pass (451/451).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Converts settings tab section headings in `src/settings.ts` from Title Case to sentence case to align with Obsidian UI conventions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d58dbb7c1ee3cd10818274081e57ea965025420. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated settings section heading formatting for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->