### PR TITLE
[codex] Migrate Granola integration to MCP OAuth

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,9 +1,0 @@
-node_modules/
-build/
-dist/
-tests/
-**/*.test.ts
-**/*.spec.ts
-jest.config.js
-esbuild.config.mjs
-version-bump.mjs

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,18 @@
 		"no-var": "error",
 		"no-undef": "off"
 	},
-	"ignorePatterns": ["main.js", "build/", "dist/", "node_modules/"],
+	"ignorePatterns": [
+		"main.js",
+		"build/",
+		"dist/",
+		"node_modules/",
+		"tests/",
+		"**/*.test.ts",
+		"**/*.spec.ts",
+		"jest.config.js",
+		"esbuild.config.mjs",
+		"version-bump.mjs"
+	],
 	"overrides": [
 		{
 			"files": ["*.ts", "*.tsx"],

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -53,7 +53,7 @@ fi
 
 # 5. Initialization order tests (catches logger and component issues)
 echo "🔧 Running initialization order tests..."
-if ! npm test -- --testPathPattern="initialization-order.test.ts" --silent; then
+if ! npm test -- --testPathPatterns="initialization-order.test.ts" --silent; then
     echo "❌ Initialization order tests failed!"
     echo "💡 Check component initialization order and dependencies"
     exit 1
@@ -61,7 +61,7 @@ fi
 
 # 6. Bundle tests (catches issues in built code)
 echo "📦 Running bundle integration tests..."
-if ! npm test -- --testPathPattern="bundle.test.ts" --silent; then
+if ! npm test -- --testPathPatterns="bundle.test.ts" --silent; then
     echo "❌ Bundle tests failed!"
     echo "💡 Issues detected in built plugin code"
     exit 1

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,5 @@
 import { Plugin, Notice } from 'obsidian';
-import { GranolaAuth } from './src/auth';
+import { GranolaAuth, GranolaAuthData } from './src/auth';
 import { GranolaAPI } from './src/api';
 import { ProseMirrorConverter } from './src/converter';
 import { DuplicateDetector } from './src/services/duplicate-detector';
@@ -11,7 +11,7 @@ import { GranolaSettingTab } from './src/settings';
 
 // Error Message Constants
 const ERROR_MESSAGES = {
-	CREDENTIALS: 'Please check your Granola credentials and ensure the app is properly logged in.',
+	CREDENTIALS: 'Please connect your Granola account with the browser OAuth flow.',
 	NETWORK: 'Network error - please check your internet connection and try again.',
 	RATE_LIMIT: 'Rate limit exceeded - please wait a moment and try again.',
 	FILE_SYSTEM: 'File system error - check vault permissions and available disk space.',
@@ -118,9 +118,25 @@ export default class GranolaImporterPlugin extends Plugin {
 		}
 
 		// Initialize core components
-		this.auth = new GranolaAuth();
+		this.auth = new GranolaAuth({
+			getData: async () =>
+				((await this.loadData()) ?? {}) as GranolaAuthData & Record<string, unknown>,
+			saveData: async data => {
+				await this.saveData(data);
+			},
+			openUrl: url => {
+				window.open(url);
+			},
+		});
 		this.api = new GranolaAPI(this.auth);
 		this.converter = new ProseMirrorConverter(this.logger, this.settings);
+
+		this.registerObsidianProtocolHandler('granola-auth', params => {
+			const code = params.code;
+			if (typeof code === 'string' && code.length > 0) {
+				void this.handleAuthCallback(code);
+			}
+		});
 
 		// Initialize selective import services
 		this.duplicateDetector = new DuplicateDetector(this.app.vault);
@@ -189,6 +205,20 @@ export default class GranolaImporterPlugin extends Plugin {
 	 */
 	onunload(): void {
 		// Clean up resources when plugin is disabled
+		void this.api?.disconnect();
+	}
+
+	private async handleAuthCallback(code: string): Promise<void> {
+		try {
+			await this.api.finishAuth(code);
+			new Notice('Connected to Granola.', 5000);
+		} catch (error) {
+			this.logger.error('Granola OAuth callback failed:', error);
+			new Notice(
+				`Failed to complete Granola authorization: ${error instanceof Error ? error.message : 'Unknown error'}`,
+				8000
+			);
+		}
 	}
 
 	/**
@@ -460,7 +490,7 @@ export default class GranolaImporterPlugin extends Plugin {
 					report += `- **${trulyEmptyDocs} documents** were created but never edited. These can be safely skipped during import.\n`;
 				}
 				if (conversionFailures > 0) {
-					report += `- **${conversionFailures} documents** may have content that failed to convert. Check these in Granola desktop app.\n`;
+					report += `- **${conversionFailures} documents** may have content that failed to convert. Check these in Granola.\n`;
 				}
 				report += `\n*Document IDs are available in debug logs when debug mode is enabled.*`;
 			} else {
@@ -565,7 +595,14 @@ export default class GranolaImporterPlugin extends Plugin {
 	 */
 	async loadSettings(): Promise<void> {
 		const savedData = await this.loadData();
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, savedData);
+		const {
+			oauthTokens: _oauthTokens,
+			oauthClientInfo: _oauthClientInfo,
+			oauthCodeVerifier: _oauthCodeVerifier,
+			oauthDiscoveryState: _oauthDiscoveryState,
+			...settingsData
+		} = (savedData ?? {}) as GranolaAuthData & Partial<GranolaSettings>;
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, settingsData);
 
 		// Migration: If user has custom template but no toggle setting, enable it
 		if (
@@ -585,7 +622,11 @@ export default class GranolaImporterPlugin extends Plugin {
 	 * @returns {Promise<void>} Resolves when settings are saved
 	 */
 	async saveSettings(): Promise<void> {
-		await this.saveData(this.settings);
+		const existingData = ((await this.loadData()) ?? {}) as Record<string, unknown>;
+		await this.saveData({
+			...existingData,
+			...this.settings,
+		});
 
 		// Update converter settings if it exists
 		if (this.converter) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,24 +8,27 @@
 			"name": "obsidian-granola-importer",
 			"version": "1.1.3",
 			"license": "MIT",
+			"dependencies": {
+				"@modelcontextprotocol/sdk": "^1.27.1"
+			},
 			"devDependencies": {
 				"@types/jest": "^30.0.0",
 				"@types/node": "^16.11.6",
-				"@typescript-eslint/eslint-plugin": "5.29.0",
-				"@typescript-eslint/parser": "5.29.0",
+				"@typescript-eslint/eslint-plugin": "^8.59.4",
+				"@typescript-eslint/parser": "^8.59.4",
 				"builtin-modules": "3.3.0",
 				"esbuild": "0.25.5",
-				"eslint": "8.57.1",
-				"jest": "^29.7.0",
-				"jest-environment-jsdom": "^29.7.0",
+				"eslint": "^10.4.0",
+				"jest": "^30.4.2",
+				"jest-environment-jsdom": "^30.4.1",
 				"jest-junit": "^16.0.0",
-				"jsdom": "^26.1.0",
+				"jsdom": "^29.1.1",
 				"obsidian": "latest",
 				"prettier": "^3.0.0",
-				"ts-jest": "^29.4.5",
+				"ts-jest": "^29.4.9",
 				"tslib": "2.4.0",
-				"typedoc": "^0.25.13",
-				"typescript": "4.7.4"
+				"typedoc": "^0.28.19",
+				"typescript": "^5.4.5"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -43,25 +46,55 @@
 			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+			"version": "5.1.11",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+			"integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/css-calc": "^2.1.3",
-				"@csstools/css-color-parser": "^3.0.9",
-				"@csstools/css-parser-algorithms": "^3.0.4",
-				"@csstools/css-tokenizer": "^3.0.3",
-				"lru-cache": "^10.4.3"
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@csstools/css-calc": "^3.2.0",
+				"@csstools/css-color-parser": "^4.1.0",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+			"integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
 			"dev": true,
-			"license": "ISC"
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@asamuzakjp/nwsapi": "^2.3.9",
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.2.1",
+				"is-potential-custom-element-name": "^1.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/generational-cache": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+			"integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/nwsapi": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.27.1",
@@ -206,9 +239,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-			"integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -226,9 +259,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -331,13 +364,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-			"integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+			"integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -373,13 +406,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-			"integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+			"integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -499,13 +532,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-			"integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+			"integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -559,14 +592,14 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.27.7",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.7.tgz",
-			"integrity": "sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1"
+				"@babel/helper-validator-identifier": "^7.28.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -578,6 +611,19 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@bramus/specificity": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"css-tree": "^3.0.0"
+			},
+			"bin": {
+				"specificity": "bin/cli.js"
+			}
 		},
 		"node_modules/@codemirror/state": {
 			"version": "6.5.2",
@@ -603,9 +649,9 @@
 			}
 		},
 		"node_modules/@csstools/color-helpers": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
-			"integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -619,13 +665,13 @@
 			],
 			"license": "MIT-0",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@csstools/css-calc": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+			"integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
 			"dev": true,
 			"funding": [
 				{
@@ -639,17 +685,17 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
 			}
 		},
 		"node_modules/@csstools/css-color-parser": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
-			"integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+			"integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
 			"dev": true,
 			"funding": [
 				{
@@ -663,21 +709,21 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^5.0.2",
-				"@csstools/css-calc": "^2.1.4"
+				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/css-calc": "^3.2.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
 			"dev": true,
 			"funding": [
 				{
@@ -691,16 +737,41 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+			"integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@csstools/css-tokenizer": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
 			"dev": true,
 			"funding": [
 				{
@@ -714,7 +785,41 @@
 			],
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -1118,10 +1223,11 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-			"integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"eslint-visitor-keys": "^3.4.3"
 			},
@@ -1136,59 +1242,199 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-			"integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+			"integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
-		"node_modules/@eslint/eslintrc": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+		"node_modules/@eslint/config-array": {
+			"version": "0.23.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+			"integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"ajv": "^6.12.4",
-				"debug": "^4.3.2",
-				"espree": "^9.6.0",
-				"globals": "^13.19.0",
-				"ignore": "^5.2.0",
-				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.0",
-				"minimatch": "^3.1.2",
-				"strip-json-comments": "^3.1.1"
+				"@eslint/object-schema": "^3.0.5",
+				"debug": "^4.3.1",
+				"minimatch": "^10.2.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
-				"url": "https://opencollective.com/eslint"
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/@eslint/js": {
-			"version": "8.57.1",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+		"node_modules/@eslint/config-helpers": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+			"integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
 			"dev": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-			"integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-			"deprecated": "Use @eslint/config-array instead",
-			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.3",
-				"debug": "^4.3.1",
-				"minimatch": "^3.0.5"
+				"@eslint/core": "^1.2.1"
 			},
 			"engines": {
-				"node": ">=10.10.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/core": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/object-schema": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+			"integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/plugin-kit": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+			"integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1",
+				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+			"integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@gerrit0/mini-shiki": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+			"integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/engine-oniguruma": "^3.23.0",
+				"@shikijs/langs": "^3.23.0",
+				"@shikijs/themes": "^3.23.0",
+				"@shikijs/types": "^3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			}
+		},
+		"node_modules/@hono/node-server": {
+			"version": "1.19.14",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.14.1"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
+		"node_modules/@humanfs/core": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+			"integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/types": "^0.15.0"
+			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/node": {
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+			"integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/core": "^0.19.2",
+				"@humanfs/types": "^0.15.0",
+				"@humanwhocodes/retry": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/types": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+			"integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18.0"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -1196,6 +1442,7 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12.22"
 			},
@@ -1204,12 +1451,66 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
-		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-			"deprecated": "Use @eslint/object-schema instead",
-			"dev": true
+		"node_modules/@humanwhocodes/retry": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+			"integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
@@ -1228,16 +1529,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
 		"node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1250,20 +1541,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -1308,16 +1585,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/@istanbuljs/schema": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -1329,128 +1596,61 @@
 			}
 		},
 		"node_modules/@jest/console": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
-			"integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+			"integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
+				"chalk": "^4.1.2",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/console/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/console/node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/console/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/console/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/core": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
-			"integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+			"integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/reporters": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/console": "30.4.1",
+				"@jest/pattern": "30.4.0",
+				"@jest/reporters": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.9",
-				"jest-changed-files": "^29.7.0",
-				"jest-config": "^29.7.0",
-				"jest-haste-map": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-resolve-dependencies": "^29.7.0",
-				"jest-runner": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"jest-watcher": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"strip-ansi": "^6.0.0"
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"exit-x": "^0.2.2",
+				"fast-json-stable-stringify": "^2.1.0",
+				"graceful-fs": "^4.2.11",
+				"jest-changed-files": "30.4.1",
+				"jest-config": "30.4.2",
+				"jest-haste-map": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-resolve-dependencies": "30.4.2",
+				"jest-runner": "30.4.2",
+				"jest-runtime": "30.4.2",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"jest-watcher": "30.4.1",
+				"pretty-format": "30.4.1",
+				"slash": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -1461,77 +1661,40 @@
 				}
 			}
 		},
-		"node_modules/@jest/core/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/core/node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+		"node_modules/@jest/core/node_modules/@jest/pattern": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/core/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
+				"jest-regex-util": "30.4.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@jest/core/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+		"node_modules/@jest/core/node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
 			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": ">=8"
 			}
 		},
 		"node_modules/@jest/diff-sequences": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
-			"integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+			"integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1539,314 +1702,98 @@
 			}
 		},
 		"node_modules/@jest/environment": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
-			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+			"integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"jest-mock": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/jest-mock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/environment/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/expect": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
-			"integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"expect": "^29.7.0",
-				"jest-snapshot": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/expect-utils": {
-			"version": "30.0.3",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.3.tgz",
-			"integrity": "sha512-SMtBvf2sfX2agcT0dA9pXwcUrKvOSDqBY4e4iRfT+Hya33XzV35YVg+98YQFErVGA/VR1Gto5Y2+A6G9LSQ3Yg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.0.1"
+				"jest-mock": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@jest/expect/node_modules/@jest/expect-utils": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-			"integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+		"node_modules/@jest/environment-jsdom-abstract": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.4.1.tgz",
+			"integrity": "sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"jest-get-type": "^29.6.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/expect": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-			"integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/expect-utils": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-diff": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-			"integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"diff-sequences": "^29.6.3",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-matcher-utils": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-			"integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/expect/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/jsdom": "^21.1.7",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@jest/expect/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+		"node_modules/@jest/expect": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+			"integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
+				"expect": "30.4.1",
+				"jest-snapshot": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect-utils": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+			"integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/fake-timers": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
-			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+			"integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@sinonjs/fake-timers": "^10.0.2",
+				"@jest/types": "30.4.1",
+				"@sinonjs/fake-timers": "^15.4.0",
 				"@types/node": "*",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/jest-mock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/get-type": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.0.1.tgz",
-			"integrity": "sha512-AyYdemXCptSRFirI5EPazNxyPwAL0jXt3zceFjaj8NFiKP9pOi0bfXonf6qkf82z2t3QWPeLCWWw4stPBzctLw==",
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+			"integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1854,112 +1801,54 @@
 			}
 		},
 		"node_modules/@jest/globals": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
-			"integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+			"integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"jest-mock": "^29.7.0"
+				"@jest/environment": "30.4.1",
+				"@jest/expect": "30.4.1",
+				"@jest/types": "30.4.1",
+				"jest-mock": "30.4.1"
 			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/jest-mock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/globals/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/pattern": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"jest-regex-util": "30.0.1"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/@jest/pattern/node_modules/jest-regex-util": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
-			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/reporters": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
-			"integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+			"integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@jridgewell/trace-mapping": "^0.3.18",
+				"@jest/console": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@jridgewell/trace-mapping": "^0.3.25",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"exit": "^0.1.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
+				"chalk": "^4.1.2",
+				"collect-v8-coverage": "^1.0.2",
+				"exit-x": "^0.2.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
 				"istanbul-lib-coverage": "^3.0.0",
 				"istanbul-lib-instrument": "^6.0.0",
 				"istanbul-lib-report": "^3.0.0",
-				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-lib-source-maps": "^5.0.0",
 				"istanbul-reports": "^3.1.3",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-worker": "^29.7.0",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-worker": "30.4.1",
 				"slash": "^3.0.0",
-				"string-length": "^4.0.1",
-				"strip-ansi": "^6.0.0",
+				"string-length": "^4.0.2",
 				"v8-to-istanbul": "^9.0.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -1970,194 +1859,139 @@
 				}
 			}
 		},
-		"node_modules/@jest/reporters/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
 		"node_modules/@jest/schemas": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@sinclair/typebox": "^0.27.8"
+				"@sinclair/typebox": "^0.34.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/snapshot-utils": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+			"integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"natural-compare": "^1.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/source-map": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
-			"integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+			"integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"callsites": "^3.0.0",
-				"graceful-fs": "^4.2.9"
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"callsites": "^3.1.0",
+				"graceful-fs": "^4.2.11"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/test-result": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
-			"integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+			"integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"collect-v8-coverage": "^1.0.0"
+				"@jest/console": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"collect-v8-coverage": "^1.0.2"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/test-sequencer": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
-			"integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+			"integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
+				"@jest/test-result": "30.4.1",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/transform": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-			"integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+			"integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@jest/types": "^29.6.3",
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"babel-plugin-istanbul": "^6.1.1",
-				"chalk": "^4.0.0",
+				"@babel/core": "^7.27.4",
+				"@jest/types": "30.4.1",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"babel-plugin-istanbul": "^7.0.1",
+				"chalk": "^4.1.2",
 				"convert-source-map": "^2.0.0",
 				"fast-json-stable-stringify": "^2.1.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"pirates": "^4.0.4",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
+				"pirates": "^4.0.7",
 				"slash": "^3.0.0",
-				"write-file-atomic": "^4.0.2"
+				"write-file-atomic": "^5.0.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/transform/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
 				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/types/node_modules/@jest/pattern": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -2220,45 +2054,164 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/@nodelib/fs.scandir": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"dev": true,
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.27.1",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+			"integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+			"license": "MIT",
 			"dependencies": {
-				"@nodelib/fs.stat": "2.0.5",
-				"run-parallel": "^1.1.9"
+				"@hono/node-server": "^1.19.9",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
 			},
 			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@nodelib/fs.stat": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true,
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/@nodelib/fs.walk": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"dev": true,
-			"dependencies": {
-				"@nodelib/fs.scandir": "2.1.5",
-				"fastq": "^1.6.0"
+				"node": ">=18"
 			},
-			"engines": {
-				"node": ">= 8"
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
+				}
 			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@pkgr/core": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+			"integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/pkgr"
+			}
+		},
+		"node_modules/@shikijs/engine-oniguruma": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+			"integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.23.0",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			}
+		},
+		"node_modules/@shikijs/langs": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+			"integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.23.0"
+			}
+		},
+		"node_modules/@shikijs/themes": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+			"integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.23.0"
+			}
+		},
+		"node_modules/@shikijs/types": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+			"integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
+		"node_modules/@shikijs/vscode-textmate": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.27.8",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2273,23 +2226,24 @@
 			}
 		},
 		"node_modules/@sinonjs/fake-timers": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+			"version": "15.4.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+			"integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@sinonjs/commons": "^3.0.0"
+				"@sinonjs/commons": "^3.0.1"
 			}
 		},
-		"node_modules/@tootallnate/once": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">= 10"
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@types/babel__core": {
@@ -2328,13 +2282,13 @@
 			}
 		},
 		"node_modules/@types/babel__traverse": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
-			"integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+			"integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.20.7"
+				"@babel/types": "^7.28.2"
 			}
 		},
 		"node_modules/@types/codemirror": {
@@ -2346,20 +2300,27 @@
 				"@types/tern": "*"
 			}
 		},
+		"node_modules/@types/esrecurse": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"dev": true
 		},
-		"node_modules/@types/graceful-fs": {
-			"version": "4.1.9",
-			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
-			"integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+		"node_modules/@types/hast": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/node": "*"
+				"@types/unist": "*"
 			}
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
@@ -2401,9 +2362,9 @@
 			}
 		},
 		"node_modules/@types/jsdom": {
-			"version": "20.0.1",
-			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
-			"integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+			"version": "21.1.7",
+			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+			"integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2416,7 +2377,8 @@
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/node": {
 			"version": "16.18.126",
@@ -2447,6 +2409,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/yargs": {
 			"version": "17.0.33",
 			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -2465,115 +2434,149 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.29.0.tgz",
-			"integrity": "sha512-kgTsISt9pM53yRFQmLZ4npj99yGl3x3Pl7z4eA66OuTzAGC4bQB5H5fuLwPnqTKU3yyrrg4MIhjF17UYnL4c0w==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
+			"integrity": "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.29.0",
-				"@typescript-eslint/type-utils": "5.29.0",
-				"@typescript-eslint/utils": "5.29.0",
-				"debug": "^4.3.4",
-				"functional-red-black-tree": "^1.0.1",
-				"ignore": "^5.2.0",
-				"regexpp": "^3.2.0",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"@eslint-community/regexpp": "^4.12.2",
+				"@typescript-eslint/scope-manager": "8.59.4",
+				"@typescript-eslint/type-utils": "8.59.4",
+				"@typescript-eslint/utils": "8.59.4",
+				"@typescript-eslint/visitor-keys": "8.59.4",
+				"ignore": "^7.0.5",
+				"natural-compare": "^1.4.0",
+				"ts-api-utils": "^2.5.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^5.0.0",
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
+				"@typescript-eslint/parser": "^8.59.4",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.29.0.tgz",
-			"integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
+			"integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.29.0",
-				"@typescript-eslint/types": "5.29.0",
-				"@typescript-eslint/typescript-estree": "5.29.0",
-				"debug": "^4.3.4"
+				"@typescript-eslint/scope-manager": "8.59.4",
+				"@typescript-eslint/types": "8.59.4",
+				"@typescript-eslint/typescript-estree": "8.59.4",
+				"@typescript-eslint/visitor-keys": "8.59.4",
+				"debug": "^4.4.3"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/project-service": {
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
+			"integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.59.4",
+				"@typescript-eslint/types": "^8.59.4",
+				"debug": "^4.4.3"
 			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
-			"integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
+			"integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "5.29.0",
-				"@typescript-eslint/visitor-keys": "5.29.0"
+				"@typescript-eslint/types": "8.59.4",
+				"@typescript-eslint/visitor-keys": "8.59.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.29.0.tgz",
-			"integrity": "sha512-JK6bAaaiJozbox3K220VRfCzLa9n0ib/J+FHIwnaV3Enw/TO267qe0pM1b1QrrEuy6xun374XEAsRlA86JJnyg==",
+		"node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
+			"integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
 			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/utils": "5.29.0",
-				"debug": "^4.3.4",
-				"tsutils": "^3.21.0"
-			},
+			"license": "MIT",
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "*"
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils": {
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz",
+			"integrity": "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.59.4",
+				"@typescript-eslint/typescript-estree": "8.59.4",
+				"@typescript-eslint/utils": "8.59.4",
+				"debug": "^4.4.3",
+				"ts-api-utils": "^2.5.0"
 			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.29.0.tgz",
-			"integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
+			"integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2581,92 +2584,487 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
-			"integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
+			"integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "5.29.0",
-				"@typescript-eslint/visitor-keys": "5.29.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"@typescript-eslint/project-service": "8.59.4",
+				"@typescript-eslint/tsconfig-utils": "8.59.4",
+				"@typescript-eslint/types": "8.59.4",
+				"@typescript-eslint/visitor-keys": "8.59.4",
+				"debug": "^4.4.3",
+				"minimatch": "^10.2.2",
+				"semver": "^7.7.3",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.5.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/utils": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.29.0.tgz",
-			"integrity": "sha512-3Eos6uP1nyLOBayc/VUdKZikV90HahXE5Dx9L5YlSd/7ylQPXhLk1BYb29SDgnBnTp+jmSZUU0QxUiyHgW4p7A==",
-			"dev": true,
-			"dependencies": {
-				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.29.0",
-				"@typescript-eslint/types": "5.29.0",
-				"@typescript-eslint/typescript-estree": "5.29.0",
-				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@typescript-eslint/utils": {
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz",
+			"integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@typescript-eslint/scope-manager": "8.59.4",
+				"@typescript-eslint/types": "8.59.4",
+				"@typescript-eslint/typescript-estree": "8.59.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
-			"integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
+			"version": "8.59.4",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
+			"integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "5.29.0",
-				"eslint-visitor-keys": "^3.3.0"
+				"@typescript-eslint/types": "8.59.4",
+				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@ungap/structured-clone": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-			"dev": true
-		},
-		"node_modules/abab": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-			"integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-			"deprecated": "Use your platform's native atob() and btoa() methods instead",
+		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
 			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+			"integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.0.tgz",
+			"integrity": "sha512-FmIJ5Bq2UUrpj2TrJiOvtfvgh98QqB3PKVqWrHp0SrYqlNSlch4YXToiiNK+mSTNFes07DipzT/JpJIq8xsOrg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-android-arm64": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.0.tgz",
+			"integrity": "sha512-XqE7sTuM4wquiiSptDC18/7SRh5LOQhmjRgu7j65T+m7lP0FzJQl0fSL+Zd7aATVJciVpcNkk0ml4hMwASvfXQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-arm64": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.0.tgz",
+			"integrity": "sha512-7aOfLOGYIh3Whvzv6fi3bA9aj8tuf7XDYbzTtsMeXixdRGLT6luR1htBSbjvWXyCn4TbKgz5SDa5gURYdlM0GQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-x64": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.0.tgz",
+			"integrity": "sha512-2NiHBibXXDCBnjpzpwHoq4Fs6kvt9QYD6ravNA3D8KQaKr7r0qu6CyvqJfDLYssijCSs2UwEmkKcAmCxP/HOXA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-freebsd-x64": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.0.tgz",
+			"integrity": "sha512-x/k1Vy1QoDrOYLJzQg2/WsRGQPS0Saw4basKqjZDQlPdkSApsvDdB9h8oRQDUTJCCazSlqLm+Ry9NQFlJicacQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.0.tgz",
+			"integrity": "sha512-zuHruxqemJqM2lrVwIgw7o3/0rLrskWDqVRAc8974nNy3cZR2N9cfatIE5PzmSNeRSafh0rAaS3ev294yCyj7A==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.0.tgz",
+			"integrity": "sha512-s2WgKQXQXhV14OT3jNoS1jN4c+8Mvamxq6jG3L7Igl8teXaGZvjI3RfZksqoxL3UAEin9UkZSApXZ+shocI1ZQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.0.tgz",
+			"integrity": "sha512-ghMWlxxa3aCW9sk5FpzrTXSo/NSanKs/RovDal5q+T2Q+dAKLFyGXWmQ6AAMsl6k/TgXHw+jj9Q9sELLx9mfJw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.0.tgz",
+			"integrity": "sha512-ldOaKTzXNIHjGzRtzgfh+g6mqt30Q8hnR+EFdfeKYgeuMqnwsllk6IaN2kadvuRRQNBr1ycI45pmgGA5EUxzuA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.0.tgz",
+			"integrity": "sha512-PQRjWSz5v+7K9CHh8a11t6JHfmuG2o3ozHgj/9IsEtSMBc/S8p8eZoJO0+i7FUq0JEjnIfLRLUADXOF/2jx4SQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.0.tgz",
+			"integrity": "sha512-slpQUuAp3+I0jsFyHxBaqETZSe8+OaG019nDOCBD0ZqZSNv0z7lMXKDgpH9BsSD+1Z5BSvV1QUbWS/MbGxpI+A==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.0.tgz",
+			"integrity": "sha512-v30e31aTFDfl1R+On53cNpd4sMQ+lzYTE4dxVia1B++Ds+27lEZSOlwjPfPN20mxb9ENis1mwUW+5SO6OzXJcA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.0.tgz",
+			"integrity": "sha512-yn6cnDhoH1IOgYvLnTeu7iAf1iknc7SXjqyLPCr3umbaeuFD8Uy2x3c3F82x2SDVEX/JpEkAGNd18lUBw4w9aQ==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.0.tgz",
+			"integrity": "sha512-M0zUTXIoRbPdWmLOs8hG3CnLVKTMbcAkC1++GJzjLAlGfH5gvhbePa6+TFniTgqiizGr0/3fdXI7R8aNwy/N4g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.0.tgz",
+			"integrity": "sha512-GJUwROe22qValEd7JRT7FG/u36Iv/IL9AedRw7pEdbc8KcfbODcygvQHAVigBFReylyLe8UkPYxJy7F5Sm+Ldw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-openharmony-arm64": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.0.tgz",
+			"integrity": "sha512-UwIkgOapYxrSPf8KTOtXeZKJD69upM9hQQuty1W0wQAJwsZrJSXFEoxuJ6lcjmEp/iJvx5PUknMqqBXJlzPTyw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-wasm32-wasi": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.0.tgz",
+			"integrity": "sha512-hE7r1jGIYXTR+inEZxKpUUT+P44RS/J5fz6x5UVvLjVsmHlkpeHOetRs5eglgoPskXwfROZlChCWBq+UoS+6Qg==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
+				"@napi-rs/wasm-runtime": "^1.1.4"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.0.tgz",
+			"integrity": "sha512-zkwy74gxj0z6G6KxCaVsQJQDlLs8g3sUYtNJYrmThB0GHsK7cmCFtRLLqaeFUvf+K2lWG8KXv1PpQr18NgNOWw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.0.tgz",
+			"integrity": "sha512-dDLr9aigi1kz+sjL9o/TSVe+5Xf5zjSrXlSJALCJE2hY/J2Ml1qKxmFZYJVEWvp72hRjIxnHH83o0cPXLkJqiA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.0.tgz",
+			"integrity": "sha512-xLJGnOAnh4eYwZLoPW27FsCAI1zwgXpeOsxUUYRNjbSmEip5j4B8fPazsoicTN+YcaAET64JyuMvazxZUe/Wzg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/accepts/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/accepts/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2674,43 +3072,20 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/acorn-globals": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
-			"integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.1.0",
-				"acorn-walk": "^8.0.2"
-			}
-		},
 		"node_modules/acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
+			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/acorn-walk": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.11.0"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/agent-base": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-			"integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2718,10 +3093,11 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -2732,6 +3108,45 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ajv-formats/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
 		},
 		"node_modules/ansi-escapes": {
 			"version": "4.3.2",
@@ -2749,19 +3164,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/ansi-escapes/node_modules/type-fest": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2770,12 +3172,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/ansi-sequence-parser": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.3.tgz",
-			"integrity": "sha512-+fksAx9eG3Ab6LDnLs3ZqZa8KVJ/jYnX+D4Qe1azX+LFGFAXqynCQLOdLpNYN/l9e7l6hMWwZbrnctqr6eSQSw==",
-			"dev": true
 		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
@@ -2807,113 +3203,74 @@
 			}
 		},
 		"node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
-		},
-		"node_modules/array-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/babel-jest": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-			"integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/transform": "^29.7.0",
-				"@types/babel__core": "^7.1.14",
-				"babel-plugin-istanbul": "^6.1.1",
-				"babel-preset-jest": "^29.6.3",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/babel-jest": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+			"integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/transform": "30.4.1",
+				"@types/babel__core": "^7.20.5",
+				"babel-plugin-istanbul": "^7.0.1",
+				"babel-preset-jest": "30.4.0",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
 				"slash": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.8.0"
+				"@babel/core": "^7.11.0 || ^8.0.0-0"
 			}
 		},
 		"node_modules/babel-plugin-istanbul": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-			"integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+			"integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"workspaces": [
+				"test/babel-8"
+			],
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@istanbuljs/load-nyc-config": "^1.0.0",
-				"@istanbuljs/schema": "^0.1.2",
-				"istanbul-lib-instrument": "^5.0.4",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-instrument": "^6.0.2",
 				"test-exclude": "^6.0.0"
 			},
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-			"integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@babel/core": "^7.12.3",
-				"@babel/parser": "^7.14.7",
-				"@istanbuljs/schema": "^0.1.2",
-				"istanbul-lib-coverage": "^3.2.0",
-				"semver": "^6.3.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/babel-plugin-istanbul/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
+				"node": ">=12"
 			}
 		},
 		"node_modules/babel-plugin-jest-hoist": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-			"integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+			"integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.3.3",
-				"@babel/types": "^7.3.3",
-				"@types/babel__core": "^7.1.14",
-				"@types/babel__traverse": "^7.0.6"
+				"@types/babel__core": "^7.20.5"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/babel-preset-current-node-syntax": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
-			"integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+			"integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2934,52 +3291,91 @@
 				"@babel/plugin-syntax-top-level-await": "^7.14.5"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.0.0"
+				"@babel/core": "^7.0.0 || ^8.0.0-0"
 			}
 		},
 		"node_modules/babel-preset-jest": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-			"integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+			"integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"babel-plugin-jest-hoist": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0"
+				"babel-plugin-jest-hoist": "30.4.0",
+				"babel-preset-current-node-syntax": "^1.2.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.0.0"
+				"@babel/core": "^7.11.0 || ^8.0.0-beta.1"
 			}
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
-		},
-		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"require-from-string": "^2.0.2"
 			}
 		},
-		"node_modules/braces": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
+		"node_modules/body-parser": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"license": "MIT",
 			"dependencies": {
-				"fill-range": "^7.1.1"
+				"bytes": "^3.1.2",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.0",
+				"iconv-lite": "^0.7.0",
+				"on-finished": "^2.4.1",
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/body-parser/node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/brace-expansion": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/browserslist": {
@@ -3057,11 +3453,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/call-bind-apply-helpers": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
 			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -3071,11 +3475,28 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -3137,26 +3558,10 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/ci-info": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/cjs-module-lexer": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3175,6 +3580,46 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/cliui/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cliui/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3187,9 +3632,9 @@
 			}
 		},
 		"node_modules/collect-v8-coverage": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-			"integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+			"integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3211,24 +3656,34 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
-		"node_modules/combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"delayed-stream": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/content-disposition": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
@@ -3237,44 +3692,39 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/create-jest": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
-			"integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
-			"dev": true,
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"chalk": "^4.0.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.9",
-				"jest-config": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"prompts": "^2.0.1"
-			},
-			"bin": {
-				"create-jest": "bin/create-jest.js"
-			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": ">= 0.6"
 			}
 		},
-		"node_modules/create-jest/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
+		"node_modules/cookie-signature": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.6.0"
+			}
+		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
+				"object-assign": "^4",
+				"vary": "^1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/crelt": {
@@ -3288,7 +3738,6 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-			"dev": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -3298,12 +3747,19 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/cssom": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-			"integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+		"node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
 		},
 		"node_modules/cssstyle": {
 			"version": "4.6.0",
@@ -3319,25 +3775,161 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/data-urls": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+		"node_modules/cssstyle/node_modules/@asamuzakjp/css-color": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"whatwg-mimetype": "^4.0.0",
-				"whatwg-url": "^14.0.0"
-			},
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
+			}
+		},
+		"node_modules/cssstyle/node_modules/@csstools/color-helpers": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/debug": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+		"node_modules/cssstyle/node_modules/@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/cssstyle/node_modules/@csstools/css-color-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/cssstyle/node_modules/@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/cssstyle/node_modules/@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/cssstyle/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/data-urls": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
 			},
@@ -3351,16 +3943,16 @@
 			}
 		},
 		"node_modules/decimal.js": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-			"integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/dedent": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
-			"integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+			"integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -3376,7 +3968,8 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/deepmerge": {
 			"version": "4.3.1",
@@ -3388,14 +3981,13 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"dev": true,
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=0.4.0"
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/detect-newline": {
@@ -3408,59 +4000,10 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/diff-sequences": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-			"integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/dir-glob": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-			"dev": true,
-			"dependencies": {
-				"path-type": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/doctrine": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-			"dev": true,
-			"dependencies": {
-				"esutils": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/domexception": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
-			"integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-			"deprecated": "Use your platform's native DOMException instead",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"webidl-conversions": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
 			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.1",
@@ -3470,6 +4013,19 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.177",
@@ -3492,11 +4048,20 @@
 			}
 		},
 		"node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/entities": {
 			"version": "6.0.1",
@@ -3512,9 +4077,9 @@
 			}
 		},
 		"node_modules/error-ex": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+			"integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3525,7 +4090,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
 			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -3535,7 +4099,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -3545,26 +4108,9 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
 			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-set-tostringtag": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.6",
-				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -3620,11 +4166,18 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT"
+		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -3632,132 +4185,79 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/escodegen": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"esprima": "^4.0.1",
-				"estraverse": "^5.2.0",
-				"esutils": "^2.0.2"
-			},
-			"bin": {
-				"escodegen": "bin/escodegen.js",
-				"esgenerate": "bin/esgenerate.js"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"optionalDependencies": {
-				"source-map": "~0.6.1"
-			}
-		},
-		"node_modules/escodegen/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/eslint": {
-			"version": "8.57.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+			"integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@eslint-community/regexpp": "^4.6.1",
-				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.57.1",
-				"@humanwhocodes/config-array": "^0.13.0",
+				"@eslint-community/eslint-utils": "^4.8.0",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@eslint/config-array": "^0.23.5",
+				"@eslint/config-helpers": "^0.6.0",
+				"@eslint/core": "^1.2.1",
+				"@eslint/plugin-kit": "^0.7.1",
+				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
-				"@nodelib/fs.walk": "^1.2.8",
-				"@ungap/structured-clone": "^1.2.0",
-				"ajv": "^6.12.4",
-				"chalk": "^4.0.0",
-				"cross-spawn": "^7.0.2",
+				"@humanwhocodes/retry": "^0.4.2",
+				"@types/estree": "^1.0.6",
+				"ajv": "^6.14.0",
+				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
-				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.2.2",
-				"eslint-visitor-keys": "^3.4.3",
-				"espree": "^9.6.1",
-				"esquery": "^1.4.2",
+				"eslint-scope": "^9.1.2",
+				"eslint-visitor-keys": "^5.0.1",
+				"espree": "^11.2.0",
+				"esquery": "^1.7.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
-				"file-entry-cache": "^6.0.1",
+				"file-entry-cache": "^8.0.0",
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
-				"globals": "^13.19.0",
-				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
-				"is-path-inside": "^3.0.3",
-				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.4.1",
-				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.1.2",
+				"minimatch": "^10.2.4",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.3",
-				"strip-ansi": "^6.0.1",
-				"text-table": "^0.2.0"
+				"optionator": "^0.9.3"
 			},
 			"bin": {
 				"eslint": "bin/eslint.js"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
-				"url": "https://opencollective.com/eslint"
+				"url": "https://eslint.org/donate"
+			},
+			"peerDependencies": {
+				"jiti": "*"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
+				"@types/esrecurse": "^4.3.1",
+				"@types/estree": "^1.0.8",
 				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
+				"estraverse": "^5.2.0"
 			},
 			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/eslint-utils": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-			"dev": true,
-			"dependencies": {
-				"eslint-visitor-keys": "^2.0.0"
-			},
-			"engines": {
-				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			},
-			"peerDependencies": {
-				"eslint": ">=5"
-			}
-		},
-		"node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
@@ -3765,6 +4265,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
 			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
@@ -3772,43 +4273,94 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/eslint-scope": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+		"node_modules/eslint/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
 			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/eslint/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^5.2.0"
+				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/eslint/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/eslint/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+		"node_modules/eslint/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">=4.0"
+				"node": ">= 4"
+			}
+		},
+		"node_modules/eslint/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.6.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.9.0",
+				"acorn": "^8.16.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.4.1"
+				"eslint-visitor-keys": "^5.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/espree/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -3829,10 +4381,11 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -3840,20 +4393,12 @@
 				"node": ">=0.10"
 			}
 		},
-		"node_modules/esquery/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/esrecurse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
@@ -3861,20 +4406,12 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/esrecurse/node_modules/estraverse": {
+		"node_modules/estraverse": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true,
+			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -3886,6 +4423,36 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+			"license": "MIT",
+			"dependencies": {
+				"eventsource-parser": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+			"integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/execa": {
@@ -3912,66 +4479,124 @@
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
 		},
-		"node_modules/exit": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-			"integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+		"node_modules/exit-x": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+			"integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/expect": {
-			"version": "30.0.3",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-30.0.3.tgz",
-			"integrity": "sha512-HXg6NvK35/cSYZCUKAtmlgCFyqKM4frEPbzrav5hRqb0GMz0E0lS5hfzYjSaiaE5ysnp/qI2aeZkeyeIAOeXzQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+			"integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/expect-utils": "30.0.3",
-				"@jest/get-type": "30.0.1",
-				"jest-matcher-utils": "30.0.3",
-				"jest-message-util": "30.0.2",
-				"jest-mock": "30.0.2",
-				"jest-util": "30.0.2"
+				"@jest/expect-utils": "30.4.1",
+				"@jest/get-type": "30.1.0",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
+		"node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express-rate-limit": {
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+			"integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^10.2.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
+		"node_modules/express/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/express/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
-		},
-		"node_modules/fast-glob": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-			"dev": true,
-			"dependencies": {
-				"@nodelib/fs.stat": "^2.0.2",
-				"@nodelib/fs.walk": "^1.2.3",
-				"glob-parent": "^5.1.2",
-				"merge2": "^1.3.0",
-				"micromatch": "^4.0.8"
-			},
-			"engines": {
-				"node": ">=8.6.0"
-			}
-		},
-		"node_modules/fast-glob/node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
-			"dependencies": {
-				"is-glob": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -3983,16 +4608,24 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-			"dev": true
-		},
-		"node_modules/fastq": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
 			"dev": true,
-			"dependencies": {
-				"reusify": "^1.0.4"
-			}
+			"license": "MIT"
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/fb-watchman": {
 			"version": "2.0.2",
@@ -4005,27 +4638,37 @@
 			}
 		},
 		"node_modules/file-entry-cache": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"flat-cache": "^3.0.4"
+				"flat-cache": "^4.0.0"
 			},
 			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
+				"node": ">=16.0.0"
 			}
 		},
-		"node_modules/fill-range": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
+		"node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"license": "MIT",
 			"dependencies": {
-				"to-regex-range": "^5.0.1"
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/find-up": {
@@ -4033,6 +4676,7 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -4045,47 +4689,80 @@
 			}
 		},
 		"node_modules/flat-cache": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
-			"dev": true,
-			"dependencies": {
-				"flatted": "^3.2.9",
-				"keyv": "^4.5.3",
-				"rimraf": "^3.0.2"
-			},
-			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
-			}
-		},
-		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-			"dev": true
-		},
-		"node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"flatted": "^3.2.9",
+				"keyv": "^4.5.4"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">=16"
+			}
+		},
+		"node_modules/flatted": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/foreground-child/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
@@ -4106,17 +4783,10 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-			"dev": true
 		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
@@ -4142,7 +4812,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
 			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
@@ -4177,7 +4846,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
 			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"dunder-proto": "^1.0.1",
@@ -4201,21 +4869,22 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
 			},
-			"engines": {
-				"node": "*"
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -4226,6 +4895,7 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -4233,46 +4903,10 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-			"dev": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/globby": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"dev": true,
-			"dependencies": {
-				"array-union": "^2.1.0",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.9",
-				"ignore": "^5.2.0",
-				"merge2": "^1.4.1",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/gopd": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
 			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -4288,16 +4922,10 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/graphemer": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-			"dev": true
-		},
 		"node_modules/handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4329,24 +4957,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
 			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-tostringtag": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-symbols": "^1.0.3"
-			},
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -4358,7 +4969,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
 			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -4367,17 +4977,26 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/hono": {
+			"version": "4.12.19",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+			"integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
 		"node_modules/html-encoding-sniffer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"whatwg-encoding": "^3.1.1"
+				"@exodus/bytes": "^1.6.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/html-escaper": {
@@ -4386,6 +5005,26 @@
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
@@ -4439,28 +5078,13 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
-			}
-		},
-		"node_modules/import-fresh": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-			"dev": true,
-			"dependencies": {
-				"parent-module": "^1.0.0",
-				"resolve-from": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/import-local": {
@@ -4498,6 +5122,7 @@
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -4506,8 +5131,25 @@
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"node_modules/ip-address": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
 		},
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
@@ -4516,27 +5158,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/is-core-module": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -4566,6 +5193,7 @@
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
 			},
@@ -4573,29 +5201,17 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.12.0"
-			}
-		},
-		"node_modules/is-path-inside": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/is-potential-custom-element-name": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
 			"license": "MIT"
 		},
 		"node_modules/is-stream": {
@@ -4614,8 +5230,7 @@
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.2",
@@ -4660,24 +5275,24 @@
 			}
 		},
 		"node_modules/istanbul-lib-source-maps": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-			"integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+			"integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.23",
 				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^3.0.0",
-				"source-map": "^0.6.1"
+				"istanbul-lib-coverage": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/istanbul-reports": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-			"integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -4688,23 +5303,39 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
 		"node_modules/jest": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
-			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+			"integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"import-local": "^3.0.2",
-				"jest-cli": "^29.7.0"
+				"@jest/core": "30.4.2",
+				"@jest/types": "30.4.1",
+				"import-local": "^3.2.0",
+				"jest-cli": "30.4.2"
 			},
 			"bin": {
 				"jest": "bin/jest.js"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -4716,193 +5347,75 @@
 			}
 		},
 		"node_modules/jest-changed-files": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
-			"integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+			"integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"execa": "^5.0.0",
-				"jest-util": "^29.7.0",
+				"execa": "^5.1.1",
+				"jest-util": "30.4.1",
 				"p-limit": "^3.1.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-changed-files/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-circus": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
-			"integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+			"integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/environment": "30.4.1",
+				"@jest/expect": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
+				"chalk": "^4.1.2",
 				"co": "^4.6.0",
-				"dedent": "^1.0.0",
-				"is-generator-fn": "^2.0.0",
-				"jest-each": "^29.7.0",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
+				"dedent": "^1.6.0",
+				"is-generator-fn": "^2.1.0",
+				"jest-each": "30.4.1",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-runtime": "30.4.2",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
 				"p-limit": "^3.1.0",
-				"pretty-format": "^29.7.0",
-				"pure-rand": "^6.0.0",
+				"pretty-format": "30.4.1",
+				"pure-rand": "^7.0.0",
 				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
+				"stack-utils": "^2.0.6"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-diff": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-			"integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"diff-sequences": "^29.6.3",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-matcher-utils": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-			"integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-circus/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-cli": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
-			"integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+			"integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"chalk": "^4.0.0",
-				"create-jest": "^29.7.0",
-				"exit": "^0.1.2",
-				"import-local": "^3.0.2",
-				"jest-config": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"yargs": "^17.3.1"
+				"@jest/core": "30.4.2",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
+				"chalk": "^4.1.2",
+				"exit-x": "^0.2.2",
+				"import-local": "^3.2.0",
+				"jest-config": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"yargs": "^17.7.2"
 			},
 			"bin": {
 				"jest": "bin/jest.js"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -4913,63 +5426,50 @@
 				}
 			}
 		},
-		"node_modules/jest-cli/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
 		"node_modules/jest-config": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
-			"integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+			"integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@jest/test-sequencer": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-jest": "^29.7.0",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"deepmerge": "^4.2.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-circus": "^29.7.0",
-				"jest-environment-node": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-runner": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"micromatch": "^4.0.4",
+				"@babel/core": "^7.27.4",
+				"@jest/get-type": "30.1.0",
+				"@jest/pattern": "30.4.0",
+				"@jest/test-sequencer": "30.4.1",
+				"@jest/types": "30.4.1",
+				"babel-jest": "30.4.1",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"deepmerge": "^4.3.1",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-circus": "30.4.2",
+				"jest-docblock": "30.4.0",
+				"jest-environment-node": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-runner": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
 				"parse-json": "^5.2.0",
-				"pretty-format": "^29.7.0",
+				"pretty-format": "30.4.1",
 				"slash": "^3.0.0",
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"@types/node": "*",
+				"esbuild-register": ">=3.4.0",
 				"ts-node": ">=9.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@types/node": {
+					"optional": true
+				},
+				"esbuild-register": {
 					"optional": true
 				},
 				"ts-node": {
@@ -4977,1242 +5477,24 @@
 				}
 			}
 		},
-		"node_modules/jest-config/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-config/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+		"node_modules/jest-config/node_modules/@jest/pattern": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-config/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-diff": {
-			"version": "30.0.3",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.3.tgz",
-			"integrity": "sha512-Q1TAV0cUcBTic57SVnk/mug0/ASyAqtSIOkr7RAlxx97llRYsM74+E8N5WdGJUlwCKwgxPAkVjKh653h1+HA9A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/diff-sequences": "30.0.1",
-				"@jest/get-type": "30.0.1",
-				"chalk": "^4.1.2",
-				"pretty-format": "30.0.2"
+				"jest-regex-util": "30.4.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-docblock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
-			"integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"detect-newline": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-each": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
-			"integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"chalk": "^4.0.0",
-				"jest-get-type": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-each/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-each/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-each/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-environment-jsdom": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
-			"integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/jsdom": "^20.0.0",
-				"@types/node": "*",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jsdom": "^20.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"canvas": "^2.5.0"
-			},
-			"peerDependenciesMeta": {
-				"canvas": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/cssstyle": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-			"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssom": "~0.3.6"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/cssstyle/node_modules/cssom": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/jest-environment-jsdom/node_modules/data-urls": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
-			"integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"abab": "^2.0.6",
-				"whatwg-mimetype": "^3.0.0",
-				"whatwg-url": "^11.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/html-encoding-sniffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
-			"integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"whatwg-encoding": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/http-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tootallnate/once": "2",
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/jest-mock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/jsdom": {
-			"version": "20.0.3",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
-			"integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"abab": "^2.0.6",
-				"acorn": "^8.8.1",
-				"acorn-globals": "^7.0.0",
-				"cssom": "^0.5.0",
-				"cssstyle": "^2.3.0",
-				"data-urls": "^3.0.2",
-				"decimal.js": "^10.4.2",
-				"domexception": "^4.0.0",
-				"escodegen": "^2.0.0",
-				"form-data": "^4.0.0",
-				"html-encoding-sniffer": "^3.0.0",
-				"http-proxy-agent": "^5.0.0",
-				"https-proxy-agent": "^5.0.1",
-				"is-potential-custom-element-name": "^1.0.1",
-				"nwsapi": "^2.2.2",
-				"parse5": "^7.1.1",
-				"saxes": "^6.0.0",
-				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^4.1.2",
-				"w3c-xmlserializer": "^4.0.0",
-				"webidl-conversions": "^7.0.0",
-				"whatwg-encoding": "^2.0.0",
-				"whatwg-mimetype": "^3.0.0",
-				"whatwg-url": "^11.0.0",
-				"ws": "^8.11.0",
-				"xml-name-validator": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"canvas": "^2.5.0"
-			},
-			"peerDependenciesMeta": {
-				"canvas": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/tough-cookie": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"psl": "^1.1.33",
-				"punycode": "^2.1.1",
-				"universalify": "^0.2.0",
-				"url-parse": "^1.5.3"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/tr46": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-			"integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"punycode": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/w3c-xmlserializer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
-			"integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"xml-name-validator": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/whatwg-encoding": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-			"integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"iconv-lite": "0.6.3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/whatwg-mimetype": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-			"integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/whatwg-url": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-			"integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tr46": "^3.0.0",
-				"webidl-conversions": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/jest-environment-jsdom/node_modules/xml-name-validator": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-			"integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/jest-environment-node": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-environment-node/node_modules/jest-mock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-environment-node/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-get-type": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-			"integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-haste-map": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-			"integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/graceful-fs": "^4.1.3",
-				"@types/node": "*",
-				"anymatch": "^3.0.3",
-				"fb-watchman": "^2.0.0",
-				"graceful-fs": "^4.2.9",
-				"jest-regex-util": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"jest-worker": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"walker": "^1.0.8"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"optionalDependencies": {
-				"fsevents": "^2.3.2"
-			}
-		},
-		"node_modules/jest-haste-map/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-junit": {
-			"version": "16.0.0",
-			"resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
-			"integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"mkdirp": "^1.0.4",
-				"strip-ansi": "^6.0.1",
-				"uuid": "^8.3.2",
-				"xml": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=10.12.0"
-			}
-		},
-		"node_modules/jest-leak-detector": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
-			"integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-leak-detector/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-leak-detector/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-matcher-utils": {
-			"version": "30.0.3",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.3.tgz",
-			"integrity": "sha512-hMpVFGFOhYmIIRGJ0HgM9htC5qUiJ00famcc9sRFchJJiLZbbVKrAztcgE6VnXLRxA3XZ0bvNA7hQWh3oHXo/A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/get-type": "30.0.1",
-				"chalk": "^4.1.2",
-				"jest-diff": "30.0.3",
-				"pretty-format": "30.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-message-util": {
-			"version": "30.0.2",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.2.tgz",
-			"integrity": "sha512-vXywcxmr0SsKXF/bAD7t7nMamRvPuJkras00gqYeB1V0WllxZrbZ0paRr3XqpFU2sYYjD0qAaG2fRyn/CGZ0aw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.0.1",
-				"@types/stack-utils": "^2.0.3",
-				"chalk": "^4.1.2",
-				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.0.2",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.6"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-message-util/node_modules/@jest/schemas": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.1.tgz",
-			"integrity": "sha512-+g/1TKjFuGrf1Hh0QPCv0gISwBxJ+MQSNXmG9zjHy7BmFhtoJ9fdNhWJp3qUKRi93AOZHXtdxZgJ1vAtz6z65w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sinclair/typebox": "^0.34.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-message-util/node_modules/@jest/types": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.1.tgz",
-			"integrity": "sha512-HGwoYRVF0QSKJu1ZQX0o5ZrUrrhj0aOOFA8hXrumD7SIzjouevhawbTjmXdwOmURdGluU9DM/XvGm3NyFoiQjw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/pattern": "30.0.1",
-				"@jest/schemas": "30.0.1",
-				"@types/istanbul-lib-coverage": "^2.0.6",
-				"@types/istanbul-reports": "^3.0.4",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.33",
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-message-util/node_modules/@sinclair/typebox": {
-			"version": "0.34.37",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.37.tgz",
-			"integrity": "sha512-2TRuQVgQYfy+EzHRTIvkhv2ADEouJ2xNS/Vq+W5EuuewBdOrvATvljZTxHWZSTYr2sTjTHpGvucaGAt67S2akw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/jest-mock": {
-			"version": "30.0.2",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.2.tgz",
-			"integrity": "sha512-PnZOHmqup/9cT/y+pXIVbbi8ID6U1XHRmbvR7MvUy4SLqhCbwpkmXhLbsWbGewHrV5x/1bF7YDjs+x24/QSvFA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.0.1",
-				"@types/node": "*",
-				"jest-util": "30.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-mock/node_modules/@jest/schemas": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.1.tgz",
-			"integrity": "sha512-+g/1TKjFuGrf1Hh0QPCv0gISwBxJ+MQSNXmG9zjHy7BmFhtoJ9fdNhWJp3qUKRi93AOZHXtdxZgJ1vAtz6z65w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sinclair/typebox": "^0.34.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-mock/node_modules/@jest/types": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.1.tgz",
-			"integrity": "sha512-HGwoYRVF0QSKJu1ZQX0o5ZrUrrhj0aOOFA8hXrumD7SIzjouevhawbTjmXdwOmURdGluU9DM/XvGm3NyFoiQjw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/pattern": "30.0.1",
-				"@jest/schemas": "30.0.1",
-				"@types/istanbul-lib-coverage": "^2.0.6",
-				"@types/istanbul-reports": "^3.0.4",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.33",
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-mock/node_modules/@sinclair/typebox": {
-			"version": "0.34.37",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.37.tgz",
-			"integrity": "sha512-2TRuQVgQYfy+EzHRTIvkhv2ADEouJ2xNS/Vq+W5EuuewBdOrvATvljZTxHWZSTYr2sTjTHpGvucaGAt67S2akw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/jest-pnp-resolver": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-			"integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			},
-			"peerDependencies": {
-				"jest-resolve": "*"
-			},
-			"peerDependenciesMeta": {
-				"jest-resolve": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/jest-regex-util": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-			"integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-resolve": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
-			"integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"resolve": "^1.20.0",
-				"resolve.exports": "^2.0.0",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-resolve-dependencies": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
-			"integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"jest-regex-util": "^29.6.3",
-				"jest-snapshot": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-resolve/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-runner": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
-			"integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/environment": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"emittery": "^0.13.1",
-				"graceful-fs": "^4.2.9",
-				"jest-docblock": "^29.7.0",
-				"jest-environment-node": "^29.7.0",
-				"jest-haste-map": "^29.7.0",
-				"jest-leak-detector": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-resolve": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-watcher": "^29.7.0",
-				"jest-worker": "^29.7.0",
-				"p-limit": "^3.1.0",
-				"source-map-support": "0.5.13"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-runner/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-runner/node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-runner/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-runner/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-runtime": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
-			"integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/globals": "^29.7.0",
-				"@jest/source-map": "^29.6.3",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"cjs-module-lexer": "^1.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"slash": "^3.0.0",
-				"strip-bom": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/jest-mock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-snapshot": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-			"integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@babel/generator": "^7.7.2",
-				"@babel/plugin-syntax-jsx": "^7.7.2",
-				"@babel/plugin-syntax-typescript": "^7.7.2",
-				"@babel/types": "^7.3.3",
-				"@jest/expect-utils": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0",
-				"chalk": "^4.0.0",
-				"expect": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^29.7.0",
-				"semver": "^7.5.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/@jest/expect-utils": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-			"integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"jest-get-type": "^29.6.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/expect": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-			"integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/expect-utils": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/jest-diff": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-			"integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"diff-sequences": "^29.6.3",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/jest-matcher-utils": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-			"integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-snapshot/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-util": {
-			"version": "30.0.2",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.2.tgz",
-			"integrity": "sha512-8IyqfKS4MqprBuUpZNlFB5l+WFehc8bfCe1HSZFHzft2mOuND8Cvi9r1musli+u6F3TqanCZ/Ik4H4pXUolZIg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "30.0.1",
-				"@types/node": "*",
-				"chalk": "^4.1.2",
-				"ci-info": "^4.2.0",
-				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-util/node_modules/@jest/schemas": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.1.tgz",
-			"integrity": "sha512-+g/1TKjFuGrf1Hh0QPCv0gISwBxJ+MQSNXmG9zjHy7BmFhtoJ9fdNhWJp3qUKRi93AOZHXtdxZgJ1vAtz6z65w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sinclair/typebox": "^0.34.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-util/node_modules/@jest/types": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.1.tgz",
-			"integrity": "sha512-HGwoYRVF0QSKJu1ZQX0o5ZrUrrhj0aOOFA8hXrumD7SIzjouevhawbTjmXdwOmURdGluU9DM/XvGm3NyFoiQjw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/pattern": "30.0.1",
-				"@jest/schemas": "30.0.1",
-				"@types/istanbul-lib-coverage": "^2.0.6",
-				"@types/istanbul-reports": "^3.0.4",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.33",
-				"chalk": "^4.1.2"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-util/node_modules/@sinclair/typebox": {
-			"version": "0.34.37",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.37.tgz",
-			"integrity": "sha512-2TRuQVgQYfy+EzHRTIvkhv2ADEouJ2xNS/Vq+W5EuuewBdOrvATvljZTxHWZSTYr2sTjTHpGvucaGAt67S2akw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/jest-util/node_modules/ci-info": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-			"integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
+		"node_modules/jest-config/node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
 			"dev": true,
 			"funding": [
 				{
@@ -6225,186 +5507,103 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/jest-util/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/jest-validate": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
-			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+		"node_modules/jest-diff": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+			"integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"camelcase": "^6.2.0",
-				"chalk": "^4.0.0",
-				"jest-get-type": "^29.6.3",
-				"leven": "^3.1.0",
-				"pretty-format": "^29.7.0"
+				"@jest/diff-sequences": "30.4.0",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-validate/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-validate/node_modules/camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/jest-validate/node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+		"node_modules/jest-docblock": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+			"integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
+				"detect-newline": "^3.1.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-watcher": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
-			"integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+		"node_modules/jest-each": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+			"integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"emittery": "^0.13.1",
-				"jest-util": "^29.7.0",
-				"string-length": "^4.0.1"
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.4.1",
+				"chalk": "^4.1.2",
+				"jest-util": "30.4.1",
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-watcher/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+		"node_modules/jest-environment-jsdom": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.4.1.tgz",
+			"integrity": "sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
+				"@jest/environment": "30.4.1",
+				"@jest/environment-jsdom-abstract": "30.4.1",
+				"jsdom": "^26.1.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/jest-worker": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+		"node_modules/jest-environment-jsdom/node_modules/data-urls": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/node": "*",
-				"jest-util": "^29.7.0",
-				"merge-stream": "^2.0.0",
-				"supports-color": "^8.0.0"
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": ">=18"
 			}
 		},
-		"node_modules/jest-worker/node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-worker/node_modules/supports-color": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
-		"node_modules/js-tokens": {
+		"node_modules/jest-environment-jsdom/node_modules/html-encoding-sniffer": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"argparse": "^2.0.1"
+				"whatwg-encoding": "^3.1.1"
 			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
+			"engines": {
+				"node": ">=18"
 			}
 		},
-		"node_modules/jsdom": {
+		"node_modules/jest-environment-jsdom/node_modules/jsdom": {
 			"version": "26.1.0",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
 			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
@@ -6444,6 +5643,640 @@
 				}
 			}
 		},
+		"node_modules/jest-environment-jsdom/node_modules/tldts": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^6.1.86"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/tldts-core": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jest-environment-jsdom/node_modules/tough-cookie": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^6.1.32"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/tr46": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/jest-environment-jsdom/node_modules/whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/jest-environment-node": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+			"integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-haste-map": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+			"integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"anymatch": "^3.1.3",
+				"fb-watchman": "^2.0.2",
+				"graceful-fs": "^4.2.11",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
+				"jest-worker": "30.4.1",
+				"picomatch": "^4.0.3",
+				"walker": "^1.0.8"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "^2.3.3"
+			}
+		},
+		"node_modules/jest-haste-map/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-junit": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
+			"integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"mkdirp": "^1.0.4",
+				"strip-ansi": "^6.0.1",
+				"uuid": "^8.3.2",
+				"xml": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=10.12.0"
+			}
+		},
+		"node_modules/jest-leak-detector": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+			"integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-matcher-utils": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+			"integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"jest-diff": "30.4.1",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-message-util": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+			"integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.4.1",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-util": "30.4.1",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.4.1",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-mock": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+			"integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"jest-util": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-pnp-resolver": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+			"integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"peerDependencies": {
+				"jest-resolve": "*"
+			},
+			"peerDependenciesMeta": {
+				"jest-resolve": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-regex-util": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-resolve": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+			"integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-pnp-resolver": "^1.2.3",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"slash": "^3.0.0",
+				"unrs-resolver": "^1.7.11"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-resolve-dependencies": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+			"integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jest-regex-util": "30.4.0",
+				"jest-snapshot": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runner": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+			"integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.4.1",
+				"@jest/environment": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"emittery": "^0.13.1",
+				"exit-x": "^0.2.2",
+				"graceful-fs": "^4.2.11",
+				"jest-docblock": "30.4.0",
+				"jest-environment-node": "30.4.1",
+				"jest-haste-map": "30.4.1",
+				"jest-leak-detector": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-resolve": "30.4.1",
+				"jest-runtime": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-watcher": "30.4.1",
+				"jest-worker": "30.4.1",
+				"p-limit": "^3.1.0",
+				"source-map-support": "0.5.13"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runtime": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+			"integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/globals": "30.4.1",
+				"@jest/source-map": "30.0.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"cjs-module-lexer": "^2.1.0",
+				"collect-v8-coverage": "^1.0.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
+				"slash": "^3.0.0",
+				"strip-bom": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+			"integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@babel/generator": "^7.27.5",
+				"@babel/plugin-syntax-jsx": "^7.27.1",
+				"@babel/plugin-syntax-typescript": "^7.27.1",
+				"@babel/types": "^7.27.3",
+				"@jest/expect-utils": "30.4.1",
+				"@jest/get-type": "30.1.0",
+				"@jest/snapshot-utils": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"babel-preset-current-node-syntax": "^1.2.0",
+				"chalk": "^4.1.2",
+				"expect": "30.4.1",
+				"graceful-fs": "^4.2.11",
+				"jest-diff": "30.4.1",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
+				"pretty-format": "30.4.1",
+				"semver": "^7.7.2",
+				"synckit": "^0.11.8"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+			"integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util/node_modules/ci-info": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
+			"integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-util/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-validate": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+			"integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.4.1",
+				"camelcase": "^6.3.0",
+				"chalk": "^4.1.2",
+				"leven": "^3.1.0",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-validate/node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/jest-watcher": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+			"integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"emittery": "^0.13.1",
+				"jest-util": "30.4.1",
+				"string-length": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-worker": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+			"integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@ungap/structured-clone": "^1.3.0",
+				"jest-util": "30.4.1",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.1.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-worker/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/jose": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/js-yaml": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "29.1.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+			"integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^5.1.11",
+				"@asamuzakjp/dom-selector": "^7.1.1",
+				"@bramus/specificity": "^2.4.2",
+				"@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+				"@exodus/bytes": "^1.15.0",
+				"css-tree": "^3.2.1",
+				"data-urls": "^7.0.0",
+				"decimal.js": "^10.6.0",
+				"html-encoding-sniffer": "^6.0.0",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.3.5",
+				"parse5": "^8.0.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^6.0.1",
+				"undici": "^7.25.0",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^8.0.1",
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.1",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jsdom/node_modules/entities": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/jsdom/node_modules/lru-cache": {
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+			"integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/jsdom/node_modules/parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
 		"node_modules/jsesc": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6461,7 +6294,8 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
@@ -6474,13 +6308,21 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/json5": {
 			"version": "2.2.3",
@@ -6495,29 +6337,14 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/jsonc-parser": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-			"dev": true
-		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
 			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"json-buffer": "3.0.1"
-			}
-		},
-		"node_modules/kleur": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/leven": {
@@ -6535,6 +6362,7 @@
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -6550,11 +6378,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"uc.micro": "^2.0.0"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -6571,12 +6410,6 @@
 			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/lodash.merge": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
 		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
@@ -6627,26 +6460,86 @@
 				"tmpl": "1.0.5"
 			}
 		},
-		"node_modules/marked": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+		"node_modules/markdown-it": {
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+			"integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
 			"dev": true,
-			"bin": {
-				"marked": "bin/marked.js"
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1",
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
 			},
+			"bin": {
+				"markdown-it": "bin/markdown-it.mjs"
+			}
+		},
+		"node_modules/markdown-it/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"license": "Python-2.0"
+		},
+		"node_modules/markdown-it/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
 			"engines": {
-				"node": ">= 12"
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
 			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
+		},
+		"node_modules/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/merge-stream": {
@@ -6655,51 +6548,6 @@
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/merge2": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/micromatch": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
-			"dependencies": {
-				"braces": "^3.0.3",
-				"picomatch": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=8.6"
-			}
-		},
-		"node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
 		},
 		"node_modules/mimic-fn": {
 			"version": "2.1.0",
@@ -6712,15 +6560,19 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/minimist": {
@@ -6731,6 +6583,16 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/mkdirp": {
@@ -6758,14 +6620,38 @@
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+		},
+		"node_modules/napi-postinstall": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+			"integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"napi-postinstall": "lib/cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/napi-postinstall"
+			}
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
@@ -6812,11 +6698,32 @@
 			}
 		},
 		"node_modules/nwsapi": {
-			"version": "2.2.20",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
-			"integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
+			"version": "2.2.23",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+			"integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/obsidian": {
 			"version": "1.8.7",
@@ -6832,11 +6739,22 @@
 				"@codemirror/view": "^6.0.0"
 			}
 		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -6862,6 +6780,7 @@
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
 			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
@@ -6879,6 +6798,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -6894,6 +6814,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -6914,17 +6835,12 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/parent-module": {
+		"node_modules/package-json-from-dist": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
 			"dev": true,
-			"dependencies": {
-				"callsites": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
+			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/parse-json": {
 			"version": "5.2.0",
@@ -6958,6 +6874,15 @@
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6972,6 +6897,7 @@
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6980,25 +6906,42 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
 		},
-		"node_modules/path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/path-type": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/path-to-regexp": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/picocolors": {
@@ -7009,10 +6952,11 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -7028,6 +6972,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/pkg-dir": {
@@ -7104,6 +7057,7 @@
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -7124,39 +7078,20 @@
 			}
 		},
 		"node_modules/pretty-format": {
-			"version": "30.0.2",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.2.tgz",
-			"integrity": "sha512-yC5/EBSOrTtqhCKfLHqoUIAXVRZnukHPwWBJWR7h84Q3Be1DRQZLncwcfLoPA5RPQ65qfiCMqgYwdUuQ//eVpg==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+			"integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/schemas": "30.0.1",
+				"@jest/schemas": "30.4.1",
 				"ansi-styles": "^5.2.0",
-				"react-is": "^18.3.1"
+				"react-is-18": "npm:react-is@^18.3.1",
+				"react-is-19": "npm:react-is@^19.2.5"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
-		},
-		"node_modules/pretty-format/node_modules/@jest/schemas": {
-			"version": "30.0.1",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.1.tgz",
-			"integrity": "sha512-+g/1TKjFuGrf1Hh0QPCv0gISwBxJ+MQSNXmG9zjHy7BmFhtoJ9fdNhWJp3qUKRi93AOZHXtdxZgJ1vAtz6z65w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sinclair/typebox": "^0.34.0"
-			},
-			"engines": {
-				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/pretty-format/node_modules/@sinclair/typebox": {
-			"version": "0.34.37",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.37.tgz",
-			"integrity": "sha512-2TRuQVgQYfy+EzHRTIvkhv2ADEouJ2xNS/Vq+W5EuuewBdOrvATvljZTxHWZSTYr2sTjTHpGvucaGAt67S2akw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/pretty-format/node_modules/ansi-styles": {
 			"version": "5.2.0",
@@ -7171,31 +7106,17 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/prompts": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-			"dev": true,
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
 			"license": "MIT",
 			"dependencies": {
-				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.5"
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
 			},
 			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/psl": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-			"integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"punycode": "^2.3.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/lupomontero"
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/punycode": {
@@ -7203,14 +7124,25 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/pure-rand": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
-			"integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+			"integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -7224,51 +7156,76 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/querystringify": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-			"dev": true,
-			"license": "MIT"
+		"node_modules/qs": {
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
-		"node_modules/queue-microtask": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
+		"node_modules/range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
-		"node_modules/react-is": {
+		"node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/raw-body/node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/react-is-18": {
+			"name": "react-is",
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/regexpp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+		"node_modules/react-is-19": {
+			"name": "react-is",
+			"version": "19.2.6",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+			"integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
 			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			}
+			"license": "MIT"
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
@@ -7280,32 +7237,13 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/requires-port": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/resolve": {
-			"version": "1.22.10",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-			"integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-			"dev": true,
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"license": "MIT",
-			"dependencies": {
-				"is-core-module": "^2.16.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			},
-			"bin": {
-				"resolve": "bin/resolve"
-			},
 			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/resolve-cwd": {
@@ -7321,7 +7259,7 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/resolve-cwd/node_modules/resolve-from": {
+		"node_modules/resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
@@ -7331,49 +7269,20 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/resolve-from": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/resolve.exports": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
-			"integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
-			"dev": true,
+		"node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
 			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/reusify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-			"dev": true,
-			"engines": {
-				"iojs": ">=1.0.0",
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
 			"dependencies": {
-				"glob": "^7.1.3"
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
 			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/rrweb-cssom": {
@@ -7383,34 +7292,10 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/run-parallel": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"queue-microtask": "^1.2.2"
-			}
-		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/saxes": {
@@ -7427,9 +7312,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+			"integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -7439,11 +7324,86 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/send/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/send/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"license": "ISC"
+		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -7455,21 +7415,80 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
 		},
-		"node_modules/shiki": {
-			"version": "0.14.7",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
-			"integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
-			"dev": true,
+		"node_modules/side-channel": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"license": "MIT",
 			"dependencies": {
-				"ansi-sequence-parser": "^1.1.0",
-				"jsonc-parser": "^3.2.0",
-				"vscode-oniguruma": "^1.7.0",
-				"vscode-textmate": "^8.0.0"
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3",
+				"side-channel-list": "^1.0.0",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/signal-exit": {
@@ -7478,13 +7497,6 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/sisteransi": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
@@ -7499,6 +7511,16 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -7546,6 +7568,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/string-length": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -7561,6 +7592,25 @@
 			}
 		},
 		"node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
@@ -7575,11 +7625,61 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/string-width-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/string-width/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -7612,6 +7712,7 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			},
@@ -7638,25 +7739,28 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/supports-preserve-symlinks-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/synckit": {
+			"version": "0.11.12",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@pkgr/core": "^0.2.9"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/synckit"
+			}
 		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
@@ -7673,29 +7777,117 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/text-table": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true
-		},
-		"node_modules/tldts": {
-			"version": "6.1.86",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+		"node_modules/test-exclude/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^6.1.86"
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/test-exclude/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/test-exclude/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.16",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/tldts": {
+			"version": "7.0.30",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+			"integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^7.0.30"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "6.1.86",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+			"version": "7.0.30",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+			"integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -7706,58 +7898,68 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
-			"dependencies": {
-				"is-number": "^7.0.0"
-			},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"license": "MIT",
 			"engines": {
-				"node": ">=8.0"
+				"node": ">=0.6"
 			}
 		},
 		"node_modules/tough-cookie": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"tldts": "^6.1.32"
+				"tldts": "^7.0.5"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/tr46": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"punycode": "^2.3.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
+			}
+		},
+		"node_modules/ts-api-utils": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.12"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4"
 			}
 		},
 		"node_modules/ts-jest": {
-			"version": "29.4.5",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.5.tgz",
-			"integrity": "sha512-HO3GyiWn2qvTQA4kTgjDcXiMwYQt68a1Y8+JuLRVpdIzm+UOLSHgl/XqR4c6nzJkq5rOkjc02O2I7P7l/Yof0Q==",
+			"version": "29.4.9",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+			"integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bs-logger": "^0.2.6",
 				"fast-json-stable-stringify": "^2.1.0",
-				"handlebars": "^4.7.8",
+				"handlebars": "^4.7.9",
 				"json5": "^2.2.3",
 				"lodash.memoize": "^4.1.2",
 				"make-error": "^1.3.6",
-				"semver": "^7.7.3",
+				"semver": "^7.7.4",
 				"type-fest": "^4.41.0",
 				"yargs-parser": "^21.1.1"
 			},
@@ -7774,7 +7976,7 @@
 				"babel-jest": "^29.0.0 || ^30.0.0",
 				"jest": "^29.0.0 || ^30.0.0",
 				"jest-util": "^29.0.0 || ^30.0.0",
-				"typescript": ">=4.3 <6"
+				"typescript": ">=4.3 <7"
 			},
 			"peerDependenciesMeta": {
 				"@babel/core": {
@@ -7816,32 +8018,12 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
-		"node_modules/tsutils": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^1.8.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"peerDependencies": {
-				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-			}
-		},
-		"node_modules/tsutils/node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true
-		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -7860,10 +8042,11 @@
 			}
 		},
 		"node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=10"
 			},
@@ -7871,64 +8054,145 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/type-is": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^2.0.0",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/type-is/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/type-is/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/type-is/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/typedoc": {
-			"version": "0.25.13",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
-			"integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
+			"version": "0.28.19",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+			"integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@gerrit0/mini-shiki": "^3.23.0",
 				"lunr": "^2.3.9",
-				"marked": "^4.3.0",
-				"minimatch": "^9.0.3",
-				"shiki": "^0.14.7"
+				"markdown-it": "^14.1.1",
+				"minimatch": "^10.2.5",
+				"yaml": "^2.8.3"
 			},
 			"bin": {
 				"typedoc": "bin/typedoc"
 			},
 			"engines": {
-				"node": ">= 16"
+				"node": ">= 18",
+				"pnpm": ">= 10"
 			},
 			"peerDependencies": {
-				"typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
+				"typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+			}
+		},
+		"node_modules/typedoc/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/typedoc/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/typedoc/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dev": true,
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "5.4.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
+		},
+		"node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/uglify-js": {
 			"version": "3.19.3",
@@ -7944,14 +8208,59 @@
 				"node": ">=0.8.0"
 			}
 		},
-		"node_modules/universalify": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+		"node_modules/undici": {
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">= 4.0.0"
+				"node": ">=20.18.1"
+			}
+		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/unrs-resolver": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.0.tgz",
+			"integrity": "sha512-hiJjN9x3O/SF2yGpNX7swfg24bi4t+uqEww16EeH9LT2I6mkGNf8uZvAS9PL1pvkA/fBagTaxbgHfYQPRfahuQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"napi-postinstall": "^0.3.4"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unrs-resolver"
+			},
+			"optionalDependencies": {
+				"@unrs/resolver-binding-android-arm-eabi": "1.12.0",
+				"@unrs/resolver-binding-android-arm64": "1.12.0",
+				"@unrs/resolver-binding-darwin-arm64": "1.12.0",
+				"@unrs/resolver-binding-darwin-x64": "1.12.0",
+				"@unrs/resolver-binding-freebsd-x64": "1.12.0",
+				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.0",
+				"@unrs/resolver-binding-linux-arm-musleabihf": "1.12.0",
+				"@unrs/resolver-binding-linux-arm64-gnu": "1.12.0",
+				"@unrs/resolver-binding-linux-arm64-musl": "1.12.0",
+				"@unrs/resolver-binding-linux-ppc64-gnu": "1.12.0",
+				"@unrs/resolver-binding-linux-riscv64-gnu": "1.12.0",
+				"@unrs/resolver-binding-linux-riscv64-musl": "1.12.0",
+				"@unrs/resolver-binding-linux-s390x-gnu": "1.12.0",
+				"@unrs/resolver-binding-linux-x64-gnu": "1.12.0",
+				"@unrs/resolver-binding-linux-x64-musl": "1.12.0",
+				"@unrs/resolver-binding-openharmony-arm64": "1.12.0",
+				"@unrs/resolver-binding-wasm32-wasi": "1.12.0",
+				"@unrs/resolver-binding-win32-arm64-msvc": "1.12.0",
+				"@unrs/resolver-binding-win32-ia32-msvc": "1.12.0",
+				"@unrs/resolver-binding-win32-x64-msvc": "1.12.0"
 			}
 		},
 		"node_modules/update-browserslist-db": {
@@ -7990,19 +8299,9 @@
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
-			}
-		},
-		"node_modules/url-parse": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"querystringify": "^2.1.1",
-				"requires-port": "^1.0.0"
 			}
 		},
 		"node_modules/uuid": {
@@ -8030,17 +8329,14 @@
 				"node": ">=10.12.0"
 			}
 		},
-		"node_modules/vscode-oniguruma": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-			"dev": true
-		},
-		"node_modules/vscode-textmate": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-			"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
-			"dev": true
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.8",
@@ -8073,19 +8369,20 @@
 			}
 		},
 		"node_modules/webidl-conversions": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
-				"node": ">=12"
+				"node": ">=20"
 			}
 		},
 		"node_modules/whatwg-encoding": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
 			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8096,34 +8393,34 @@
 			}
 		},
 		"node_modules/whatwg-mimetype": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/whatwg-url": {
-			"version": "14.2.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tr46": "^5.1.0",
-				"webidl-conversions": "^7.0.0"
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -8139,6 +8436,7 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
 			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8151,6 +8449,25 @@
 			"license": "MIT"
 		},
 		"node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
@@ -8168,30 +8485,106 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
+		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
 		},
 		"node_modules/write-file-atomic": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-			"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.7"
+				"signal-exit": "^4.0.1"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/write-file-atomic/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.18.2",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-			"integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+			"version": "8.20.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8251,6 +8644,22 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
 		"node_modules/yargs": {
 			"version": "17.7.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -8280,16 +8689,57 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/yargs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/yargs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -36,20 +36,23 @@
 	"devDependencies": {
 		"@types/jest": "^30.0.0",
 		"@types/node": "^16.11.6",
-		"@typescript-eslint/eslint-plugin": "5.29.0",
-		"@typescript-eslint/parser": "5.29.0",
+		"@typescript-eslint/eslint-plugin": "^8.59.4",
+		"@typescript-eslint/parser": "^8.59.4",
 		"builtin-modules": "3.3.0",
 		"esbuild": "0.25.5",
-		"eslint": "8.57.1",
-		"jest": "^29.7.0",
-		"jest-environment-jsdom": "^29.7.0",
+		"eslint": "^10.4.0",
+		"jest": "^30.4.2",
+		"jest-environment-jsdom": "^30.4.1",
 		"jest-junit": "^16.0.0",
-		"jsdom": "^26.1.0",
+		"jsdom": "^29.1.1",
 		"obsidian": "latest",
 		"prettier": "^3.0.0",
-		"ts-jest": "^29.4.5",
+		"ts-jest": "^29.4.9",
 		"tslib": "2.4.0",
-		"typedoc": "^0.25.13",
-		"typescript": "4.7.4"
+		"typedoc": "^0.28.19",
+		"typescript": "^5.4.5"
+	},
+	"dependencies": {
+		"@modelcontextprotocol/sdk": "^1.27.1"
 	}
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,52 +1,31 @@
-import { requestUrl } from 'obsidian';
-import { readFileSync, existsSync } from 'fs';
-import { resolve } from 'path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { GranolaAuth } from './auth';
+import { nodeFetch } from './fetch';
 
-/**
- * Represents a document from the Granola API.
- *
- * Documents contain ProseMirror JSON content under the 'notes' field that needs to be converted
- * to Markdown format for use in Obsidian. Each document includes metadata
- * such as creation/update timestamps and a unique identifier.
- *
- * @interface GranolaDocument
- * @since 1.0.0
- */
+const MCP_SERVER_URL = 'https://mcp.granola.ai/mcp';
+const DEFAULT_PAGE_SIZE = 100;
+const FETCH_BATCH_SIZE = 10;
+const DEFAULT_TIME_RANGE: SyncTimeRange = 'last_30_days';
+
+const LIST_MEETINGS_TOOL = 'list_meetings';
+const GET_MEETINGS_TOOL = 'get_meetings';
+
+export type SyncTimeRange = 'this_week' | 'last_week' | 'last_30_days';
+
 export interface GranolaDocument {
-	/** Unique identifier for the document */
 	id: string;
-
-	/** Human-readable title of the document */
 	title: string;
-
-	/** Document content in ProseMirror JSON format */
 	notes: ProseMirrorDoc;
-
-	/** Plain text version of the notes */
 	notes_plain: string;
-
-	/** Markdown version of the notes */
 	notes_markdown: string;
-
-	/** Last viewed panel containing the actual content */
 	last_viewed_panel?: {
-		/** Panel content in ProseMirror JSON format or HTML string */
 		content?: ProseMirrorDoc | string;
-		/** Additional panel metadata */
 		[key: string]: unknown;
 	};
-
-	/** ISO timestamp when the document was created */
 	created_at: string;
-
-	/** ISO timestamp when the document was last updated */
 	updated_at: string;
-
-	/** User ID of the document owner */
 	user_id: string;
-
-	/** Array of meeting attendees (if available) - can be string[] or complex object */
 	people?:
 		| string[]
 		| {
@@ -69,351 +48,401 @@ export interface GranolaDocument {
 				};
 				title?: string;
 		  };
-
-	/** Additional metadata fields */
 	[key: string]: unknown;
 }
 
-/**
- * Root document structure for ProseMirror content.
- *
- * ProseMirror documents follow a hierarchical node structure where
- * the root document contains an array of top-level nodes (paragraphs,
- * headings, lists, etc.).
- *
- * @interface ProseMirrorDoc
- * @since 1.0.0
- * @see {@link https://prosemirror.net/docs/ref/#model.Node} ProseMirror Node Documentation
- */
 export interface ProseMirrorDoc {
-	/** Always 'doc' for root document nodes */
 	type: 'doc';
-
-	/** Array of top-level content nodes (paragraphs, headings, etc.) */
 	content?: ProseMirrorNode[];
 }
 
-/**
- * Individual node within a ProseMirror document structure.
- *
- * Each node represents a semantic element (paragraph, heading, text, etc.)
- * and may contain attributes, child content, text content, or formatting marks.
- * The converter processes these nodes recursively to generate Markdown.
- *
- * @interface ProseMirrorNode
- * @since 1.0.0
- * @see {@link https://prosemirror.net/docs/ref/#model.Node} ProseMirror Node Documentation
- */
 export interface ProseMirrorNode {
-	/** Node type (paragraph, heading, text, bulletList, etc.) */
 	type: string;
-
-	/** Node-specific attributes (e.g., heading level, link href) */
 	attrs?: Record<string, unknown>;
-
-	/** Child nodes for container elements */
 	content?: ProseMirrorNode[];
-
-	/** Text content for text nodes */
 	text?: string;
-
-	/** Formatting marks applied to text (bold, italic, code, links) */
 	marks?: Array<{
-		/** Mark type (strong, em, code, link) */
 		type: string;
-		/** Mark-specific attributes (e.g., link href) */
 		attrs?: Record<string, unknown>;
 	}>;
 }
 
-/**
- * Request parameters for paginated document fetching.
- *
- * The Granola API supports pagination to handle large document collections.
- * These parameters control how many documents are returned and from what offset.
- *
- * @interface GetDocumentsRequest
- * @since 1.0.0
- */
 export interface GetDocumentsRequest {
-	/** Maximum number of documents to return (default: 100, max: 100) */
 	limit?: number;
-
-	/** Number of documents to skip for pagination (default: 0) */
 	offset?: number;
+	timeRange?: SyncTimeRange;
 }
 
-/**
- * Response structure from the Granola API document endpoint.
- *
- * Contains the requested documents along with deleted document information.
- * Note: The API no longer uses pagination - all documents are returned in a single request.
- *
- * @interface GetDocumentsResponse
- * @since 1.0.0
- */
 export interface GetDocumentsResponse {
-	/** Array of active documents */
 	docs: GranolaDocument[];
-
-	/** Array of deleted document IDs */
 	deleted: string[];
 }
 
-// API Configuration Constants
-const DEFAULT_PAGE_SIZE = 100;
-const MAX_RETRY_ATTEMPTS = 3;
-const EXPONENTIAL_BACKOFF_BASE_MS = 1000;
+interface McpTool {
+	name: string;
+	description?: string;
+	inputSchema?: Record<string, unknown>;
+}
 
-/**
- * HTTP client for interacting with the Granola REST API.
- *
- * This class handles all communication with Granola's backend services,
- * including authentication, rate limiting, retry logic, and pagination.
- * It provides a high-level interface for fetching documents while managing
- * the complexities of API interaction.
- *
- * Features:
- * - Automatic retry with exponential backoff
- * - Rate limiting compliance (200ms between requests)
- * - Pagination handling for large document collections
- * - Comprehensive error handling and categorization
- *
- * @class GranolaAPI
- * @since 1.0.0
- *
- * @example
- * ```typescript
- * const auth = new GranolaAuth();
- * await auth.loadCredentials();
- * const api = new GranolaAPI(auth);
- * const documents = await api.getAllDocuments();
- * ```
- */
+interface ParsedParticipant {
+	name: string;
+	email: string;
+	organization: string;
+	isCreator: boolean;
+}
+
+interface ParsedMeeting {
+	id: string;
+	title: string;
+	date: string;
+	participants: ParsedParticipant[];
+	privateNotes: string;
+	summary: string;
+}
+
+type ToolResult = Awaited<ReturnType<Client['callTool']>>;
+
 export class GranolaAPI {
-	/** Base URL for all Granola API endpoints */
-	private readonly baseUrl = 'https://api.granola.ai/v2';
-
-	/**
-	 * User-Agent string for API requests identifying this plugin.
-	 * Version is automatically pulled from package.json to keep it in sync.
-	 */
-	private readonly userAgent: string;
-
-	/** Authentication manager for API credentials */
+	private client: Client | null = null;
+	private transport: StreamableHTTPClientTransport | null = null;
+	private tools: McpTool[] = [];
 	private auth: GranolaAuth;
 
-	/**
-	 * Creates a new Granola API client.
-	 *
-	 * @param {GranolaAuth} auth - Authentication manager with loaded credentials
-	 *
-	 * @example
-	 * ```typescript
-	 * const auth = new GranolaAuth();
-	 * await auth.loadCredentials();
-	 * const api = new GranolaAPI(auth);
-	 * ```
-	 */
 	constructor(auth: GranolaAuth) {
 		this.auth = auth;
-
-		// Get version from package.json, fall back to static version
-		try {
-			// Try the most likely path first (relative to built main.js)
-			const packagePath = resolve(__dirname, '../package.json');
-
-			if (existsSync(packagePath)) {
-				const manifest = JSON.parse(readFileSync(packagePath, 'utf8'));
-				if (manifest?.name && manifest?.version) {
-					this.userAgent = `${manifest.name}/${manifest.version}`;
-				} else {
-					throw new Error('Invalid package.json format');
-				}
-			} else {
-				throw new Error('Package.json not found');
-			}
-		} catch {
-			// Fallback to static version if package.json is unavailable
-			this.userAgent = 'obsidian-granola-importer/1.0.0';
-		}
 	}
 
-	/**
-	 * Loads and validates Granola credentials.
-	 * This method should be called before making any API requests.
-	 *
-	 * @async
-	 * @returns {Promise<void>} Resolves when credentials are loaded and validated
-	 * @throws {Error} If credential loading fails
-	 */
+	get isConnected(): boolean {
+		return this.client !== null;
+	}
+
 	async loadCredentials(): Promise<void> {
-		await this.auth.loadCredentials();
+		await this.connect();
 	}
 
-	/**
-	 * Fetches documents from the Granola API.
-	 *
-	 * Note: The Granola API now returns all documents in a single request.
-	 * The limit and offset parameters are kept for backward compatibility
-	 * but may not have any effect on the actual API response.
-	 *
-	 * @async
-	 * @param {GetDocumentsRequest} options - Request options (may be ignored by API)
-	 * @returns {Promise<GetDocumentsResponse>} All documents with metadata
-	 * @throws {Error} If API request fails or rate limit is exceeded
-	 *
-	 * @example
-	 * ```typescript
-	 * // Fetch all documents
-	 * const response = await api.getDocuments();
-	 * console.log(`Found ${response.docs.length} documents`);
-	 * console.log(`Deleted documents: ${response.deleted.length}`);
-	 * ```
-	 */
-	async getDocuments(options: GetDocumentsRequest = {}): Promise<GetDocumentsResponse> {
-		const { limit = DEFAULT_PAGE_SIZE, offset = 0 } = options;
+	async connect(): Promise<void> {
+		await this.disconnect();
 
-		const response = await this.makeRequest('/get-documents', {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				Authorization: `Bearer ${this.auth.getBearerToken()}`,
-				'User-Agent': this.userAgent,
-			},
-			body: JSON.stringify({
-				limit,
-				offset,
-				include_last_viewed_panel: true,
-			}),
+		this.client = new Client({
+			name: 'obsidian-granola-importer',
+			version: '2.0.0',
+		});
+		this.transport = new StreamableHTTPClientTransport(new URL(MCP_SERVER_URL), {
+			authProvider: this.auth,
+			fetch: nodeFetch,
 		});
 
-		if (!response.ok) {
-			if (response.status === 429) {
-				throw new Error('Rate limit exceeded. Please try again later.');
-			}
-			throw new Error(`API request failed: ${response.status} ${response.statusText}`);
-		}
-
-		return await response.json();
-	}
-
-	/**
-	 * Fetches all documents from the user's Granola account.
-	 *
-	 * The Granola API now returns all documents in a single request,
-	 * so no pagination handling is required.
-	 *
-	 * @async
-	 * @returns {Promise<GranolaDocument[]>} Array of all documents in the account
-	 * @throws {Error} If the API request fails
-	 *
-	 * @example
-	 * ```typescript
-	 * try {
-	 *   const allDocuments = await api.getAllDocuments();
-	 *   console.log(`Retrieved ${allDocuments.length} total documents`);
-	 *
-	 *   for (const doc of allDocuments) {
-	 *     console.log(`Document: ${doc.title} (${doc.id})`);
-	 *   }
-	 * } catch (error) {
-	 *   console.error('Failed to fetch documents:', error.message);
-	 * }
-	 * ```
-	 */
-	async getAllDocuments(): Promise<GranolaDocument[]> {
-		const response = await this.getDocuments();
-
-		// Handle the new API response format
-		if (response.docs && Array.isArray(response.docs)) {
-			return response.docs;
-		} else {
-			console.error('Unexpected API response format:', response);
-			throw new Error('API returned unexpected response format');
+		try {
+			await this.client.connect(this.transport);
+			await this.discoverTools(true);
+		} catch (error) {
+			this.client = null;
+			this.transport = null;
+			throw error;
 		}
 	}
 
-	/**
-	 * Makes an HTTP request with retry logic and exponential backoff.
-	 *
-	 * This method implements robust error handling including:
-	 * - Up to 3 retry attempts for failed requests
-	 * - Exponential backoff delays (2^attempt * 1000ms)
-	 * - Special handling for rate limit (429) responses
-	 * - Network error recovery
-	 *
-	 * @private
-	 * @param {string} endpoint - API endpoint path (e.g., '/get-documents')
-	 * @param {object} options - Fetch options (method, headers, body, etc.)
-	 * @returns {Promise<Response>} The HTTP response object
-	 * @throws {Error} If all retry attempts fail
-	 *
-	 * @example
-	 * ```typescript
-	 * const response = await this.makeRequest('/get-documents', {
-	 *   method: 'POST',
-	 *   headers: { 'Authorization': `Bearer ${token}` },
-	 *   body: JSON.stringify({ limit: 100 })
-	 * });
-	 * ```
-	 */
-	private async makeRequest(
-		endpoint: string,
-		options: {
-			method?: string;
-			headers: Record<string, string>;
-			body?: string;
-		}
-	): Promise<Response> {
-		const url = `${this.baseUrl}${endpoint}`;
-
-		// Retry logic with exponential backoff
-		for (let attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
+	async disconnect(): Promise<void> {
+		if (this.client) {
 			try {
-				const response = await requestUrl({
-					url,
-					method: options.method || 'GET',
-					headers: options.headers,
-					body: options.body,
-					throw: false, // Don't throw on non-2xx status codes
-				});
-
-				// Check if response exists (can be undefined on network error)
-				if (!response || response.status === undefined) {
-					throw new Error('Network error: no response received');
-				}
-
-				// Convert requestUrl response to fetch-like Response for compatibility
-				const fetchLikeResponse = {
-					ok: response.status >= 200 && response.status < 300,
-					status: response.status,
-					statusText: '', // requestUrl doesn't provide statusText
-					headers: new Headers(response.headers),
-					json: async () => response.json,
-					text: async () => response.text || JSON.stringify(response.json),
-				} as Response;
-
-				if (response.status === 429 && attempt < MAX_RETRY_ATTEMPTS) {
-					const delay = Math.pow(2, attempt) * EXPONENTIAL_BACKOFF_BASE_MS; // Exponential backoff
-					await window.sleep(delay);
-					continue;
-				}
-
-				return fetchLikeResponse;
-			} catch (error) {
-				if (attempt === 3) {
-					const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-					throw new Error(
-						`Network request failed after ${attempt} attempts: ${errorMessage}`
-					);
-				}
-
-				const delay = Math.pow(2, attempt) * EXPONENTIAL_BACKOFF_BASE_MS;
-				await window.sleep(delay);
+				await this.client.close();
+			} catch {
+				// Ignore shutdown errors from an already-closed MCP session.
 			}
 		}
 
-		throw new Error('Maximum retry attempts exceeded');
+		this.client = null;
+		this.transport = null;
+		this.tools = [];
 	}
+
+	async finishAuth(authorizationCode: string): Promise<void> {
+		const transport = new StreamableHTTPClientTransport(new URL(MCP_SERVER_URL), {
+			authProvider: this.auth,
+			fetch: nodeFetch,
+		});
+		await transport.finishAuth(authorizationCode);
+		await this.connect();
+	}
+
+	async getDocuments(options: GetDocumentsRequest = {}): Promise<GetDocumentsResponse> {
+		const { limit = DEFAULT_PAGE_SIZE, offset = 0, timeRange = DEFAULT_TIME_RANGE } = options;
+		const allMeetings = await this.listMeetings(timeRange);
+		const selectedMeetings = allMeetings.slice(offset, offset + limit);
+
+		if (selectedMeetings.length === 0) {
+			return { docs: [], deleted: [] };
+		}
+
+		const docs = await this.fetchMeetingDetails(selectedMeetings);
+		return { docs, deleted: [] };
+	}
+
+	async getAllDocuments(): Promise<GranolaDocument[]> {
+		const allMeetings = await this.listMeetings(DEFAULT_TIME_RANGE);
+		if (allMeetings.length === 0) {
+			return [];
+		}
+
+		return this.fetchMeetingDetails(allMeetings);
+	}
+
+	async getAvailableTools(): Promise<McpTool[]> {
+		await this.ensureConnected();
+		return this.discoverTools();
+	}
+
+	private async listMeetings(timeRange: SyncTimeRange): Promise<ParsedMeeting[]> {
+		const toolName = await this.requireTool(LIST_MEETINGS_TOOL);
+		const text = await this.callToolText(toolName, { time_range: timeRange });
+		return parseMeetingsResponse(text);
+	}
+
+	private async fetchMeetingDetails(meetings: ParsedMeeting[]): Promise<GranolaDocument[]> {
+		const toolName = await this.requireTool(GET_MEETINGS_TOOL);
+		const docs: GranolaDocument[] = [];
+
+		for (let index = 0; index < meetings.length; index += FETCH_BATCH_SIZE) {
+			const batch = meetings.slice(index, index + FETCH_BATCH_SIZE);
+			const text = await this.callToolText(toolName, {
+				meeting_ids: batch.map(meeting => meeting.id),
+			});
+			const details = parseMeetingsResponse(text);
+			const detailsById = new Map(details.map(meeting => [meeting.id, meeting]));
+
+			for (const meeting of batch) {
+				docs.push(toGranolaDocument(detailsById.get(meeting.id) ?? meeting));
+			}
+		}
+
+		return docs;
+	}
+
+	private async callToolText(name: string, args: Record<string, unknown>): Promise<string> {
+		await this.ensureConnected();
+		const result = (await this.getClient().callTool({ name, arguments: args })) as ToolResult;
+		const text = extractToolText(result);
+
+		if ('isError' in result && result.isError) {
+			throw new Error(text || `Granola MCP tool failed: ${name}`);
+		}
+
+		return text;
+	}
+
+	private async requireTool(name: string): Promise<string> {
+		const tools = await this.discoverTools();
+		if (!tools.some(tool => tool.name === name)) {
+			const availableTools = tools.map(tool => tool.name).join(', ') || 'none';
+			throw new Error(
+				`Granola MCP tool "${name}" is unavailable. Available tools: ${availableTools}`
+			);
+		}
+		return name;
+	}
+
+	private async discoverTools(force = false): Promise<McpTool[]> {
+		await this.ensureConnected();
+
+		if (!force && this.tools.length > 0) {
+			return this.tools;
+		}
+
+		const result = await this.getClient().listTools();
+		this.tools = result.tools.map(tool => ({
+			name: tool.name,
+			description: tool.description,
+			inputSchema: tool.inputSchema,
+		}));
+		return this.tools;
+	}
+
+	private async ensureConnected(): Promise<void> {
+		if (!this.client) {
+			await this.connect();
+		}
+	}
+
+	private getClient(): Client {
+		if (!this.client) {
+			throw new Error('Not connected to Granola');
+		}
+		return this.client;
+	}
+}
+
+function extractToolText(result: ToolResult): string {
+	if ('content' in result && Array.isArray(result.content)) {
+		return result.content
+			.filter(item => item.type === 'text' && typeof item.text === 'string')
+			.map(item => item.text)
+			.join('\n');
+	}
+
+	if ('structuredContent' in result && result.structuredContent) {
+		return JSON.stringify(result.structuredContent);
+	}
+
+	if ('toolResult' in result) {
+		return typeof result.toolResult === 'string'
+			? result.toolResult
+			: JSON.stringify(result.toolResult);
+	}
+
+	return '';
+}
+
+function parseMeetingsResponse(text: string): ParsedMeeting[] {
+	const meetings: ParsedMeeting[] = [];
+	const meetingRegex =
+		/<meeting\s+id="([^"]+)"\s+title="([^"]*?)"\s+date="([^"]*?)">([\s\S]*?)<\/meeting>/g;
+
+	let match: RegExpExecArray | null;
+	while ((match = meetingRegex.exec(text)) !== null) {
+		const [, id, title, date, body] = match;
+		const participantsMatch = body.match(
+			/<known_participants>\s*([\s\S]*?)\s*<\/known_participants>/
+		);
+		const notesMatch = body.match(/<private_notes>\s*([\s\S]*?)\s*<\/private_notes>/);
+		const summaryMatch = body.match(/<summary>\s*([\s\S]*?)\s*<\/summary>/);
+
+		meetings.push({
+			id: decodeXml(id),
+			title: decodeXml(title),
+			date: decodeXml(date),
+			participants: participantsMatch
+				? parseParticipants(decodeXml(participantsMatch[1]))
+				: [],
+			privateNotes: notesMatch ? decodeXml(notesMatch[1].trim()) : '',
+			summary: summaryMatch ? decodeXml(summaryMatch[1].trim()) : '',
+		});
+	}
+
+	return meetings;
+}
+
+function parseParticipants(text: string): ParsedParticipant[] {
+	if (!text.trim()) {
+		return [];
+	}
+
+	return text
+		.split(/,\s*(?=[A-Z])/)
+		.map(part => {
+			const emailMatch = part.match(/<([^>]+)>/);
+			const email = emailMatch?.[1] ?? '';
+			const isCreator = part.includes('(note creator)');
+			let name = part
+				.replace(/<[^>]+>/, '')
+				.replace(/\(note creator\)/g, '')
+				.trim();
+			let organization = '';
+			const fromMatch = name.match(/^(.+?)\s+from\s+(.+)$/);
+
+			if (fromMatch) {
+				name = fromMatch[1].trim();
+				organization = fromMatch[2].trim();
+			}
+
+			return {
+				name,
+				email,
+				organization,
+				isCreator,
+			};
+		})
+		.filter(participant => participant.name || participant.email);
+}
+
+function toGranolaDocument(meeting: ParsedMeeting): GranolaDocument {
+	const timestamp = parseGranolaDate(meeting.date);
+	const markdown = buildMarkdown(meeting);
+
+	return {
+		id: meeting.id,
+		title: meeting.title || 'Untitled Meeting',
+		notes: { type: 'doc', content: [] },
+		notes_plain: markdownToPlainText(markdown),
+		notes_markdown: markdown,
+		created_at: timestamp,
+		updated_at: timestamp,
+		user_id: '',
+		people: toPeople(meeting),
+	};
+}
+
+function buildMarkdown(meeting: ParsedMeeting): string {
+	const parts: string[] = [];
+
+	if (meeting.privateNotes.trim()) {
+		parts.push(`## Notes\n\n${meeting.privateNotes.trim()}`);
+	}
+
+	if (meeting.summary.trim()) {
+		parts.push(`## Summary\n\n${meeting.summary.trim()}`);
+	}
+
+	return parts.join('\n\n').trim();
+}
+
+function toPeople(meeting: ParsedMeeting): NonNullable<GranolaDocument['people']> {
+	const creator = meeting.participants.find(participant => participant.isCreator);
+	const attendees = meeting.participants
+		.filter(participant => !participant.isCreator)
+		.map(participant => ({
+			email: participant.email || undefined,
+			details: {
+				person: {
+					name: {
+						fullName: participant.name,
+					},
+				},
+				company: participant.organization
+					? {
+							name: participant.organization,
+						}
+					: undefined,
+			},
+		}));
+
+	return {
+		attendees,
+		creator: creator
+			? {
+					name: creator.name,
+					email: creator.email || undefined,
+				}
+			: undefined,
+		title: meeting.title,
+	};
+}
+
+function parseGranolaDate(date: string): string {
+	const parsed = new Date(date);
+	if (!Number.isNaN(parsed.getTime())) {
+		return parsed.toISOString();
+	}
+
+	return new Date().toISOString();
+}
+
+function markdownToPlainText(markdown: string): string {
+	return markdown
+		.replace(/```[\s\S]*?```/g, ' ')
+		.replace(/`([^`]+)`/g, '$1')
+		.replace(/!\[[^\]]*]\([^)]+\)/g, '')
+		.replace(/\[([^\]]+)]\([^)]+\)/g, '$1')
+		.replace(/^#{1,6}\s+/gm, '')
+		.replace(/[*_~>#-]/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+function decodeXml(value: string): string {
+	return value
+		.replace(/&quot;/g, '"')
+		.replace(/&apos;/g, "'")
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&amp;/g, '&');
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,453 +1,256 @@
-import { Platform } from 'obsidian';
-import { readFileSync } from 'fs';
-import { platform as osPlatform, homedir } from 'os';
-import { join } from 'path';
+import { auth as runOAuthFlow } from '@modelcontextprotocol/sdk/client/auth.js';
+import type {
+	OAuthClientProvider,
+	OAuthDiscoveryState,
+} from '@modelcontextprotocol/sdk/client/auth.js';
+import type {
+	OAuthClientInformationMixed,
+	OAuthClientMetadata,
+	OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import { nodeFetch } from './fetch';
 
-// Authentication Constants
-const JWT_PARTS_COUNT = 3;
+const MCP_SERVER_URL = 'https://mcp.granola.ai/mcp';
+const REDIRECT_URL = 'obsidian://granola-auth';
+const TOKEN_EXPIRY_SKEW_SECONDS = 60;
 const TIMESTAMP_CONVERSION_FACTOR = 1000;
 
-/**
- * Represents the authentication credentials required for Granola API access.
- *
- * These credentials are typically obtained through the Granola desktop application's
- * OAuth flow and stored in a platform-specific configuration file.
- *
- * @interface GranolaCredentials
- * @since 1.0.0
- */
+export type GranolaOAuthTokens = OAuthTokens & {
+	obtained_at?: number;
+	expires_at?: number;
+};
+
+export interface GranolaAuthData {
+	oauthTokens?: GranolaOAuthTokens;
+	oauthClientInfo?: OAuthClientInformationMixed;
+	oauthCodeVerifier?: string;
+	oauthDiscoveryState?: OAuthDiscoveryState;
+}
+
+export interface GranolaAuthStorage {
+	getData(): Promise<(GranolaAuthData & Record<string, unknown>) | null | undefined>;
+	saveData(data: GranolaAuthData & Record<string, unknown>): Promise<void>;
+	openUrl?(url: string): void;
+}
+
 export interface GranolaCredentials {
-	/**
-	 * JWT access token for API authentication.
-	 * Used as Bearer token in Authorization headers.
-	 */
 	access_token: string;
-
-	/**
-	 * Token used to refresh expired access tokens.
-	 * Currently stored but refresh functionality is not implemented.
-	 */
-	refresh_token: string;
-
-	/**
-	 * Type of token, typically "bearer" for OAuth 2.0.
-	 * Must match expected token type for validation.
-	 */
+	refresh_token?: string;
 	token_type: string;
+	expires_at?: number;
+}
 
-	/**
-	 * Unix timestamp indicating when the access token expires.
-	 * Used to determine if token refresh is needed.
-	 */
-	expires_at: number;
+function createMemoryStorage(): GranolaAuthStorage {
+	let data: GranolaAuthData & Record<string, unknown> = {};
+
+	return {
+		async getData() {
+			return data;
+		},
+		async saveData(nextData) {
+			data = { ...nextData };
+		},
+	};
 }
 
 /**
- * OAuth token structure within the Granola configuration file.
+ * OAuth provider for Granola's MCP server.
  *
- * This interface represents the parsed cognito_tokens JSON string
- * from the supabase.json file. Contains AWS Cognito OAuth tokens.
- *
- * @interface CognitoTokens
- * @since 1.0.0
+ * The MCP SDK owns the OAuth redirects, dynamic client registration, token exchange,
+ * and refresh-token path. This class supplies Obsidian persistence and keeps the old
+ * GranolaAuth methods available for the rest of the plugin.
  */
-export interface CognitoTokens {
-	/** JWT access token from AWS Cognito OAuth flow */
-	access_token: string;
+export class GranolaAuth implements OAuthClientProvider {
+	private dataCache: (GranolaAuthData & Record<string, unknown>) | null = null;
+	private credentials: GranolaOAuthTokens | null = null;
 
-	/** Refresh token for token renewal (not yet implemented) */
-	refresh_token: string;
+	constructor(private storage: GranolaAuthStorage = createMemoryStorage()) {}
 
-	/** OAuth token type, typically "Bearer" (capitalized) */
-	token_type: string;
+	get redirectUrl(): string {
+		return REDIRECT_URL;
+	}
 
-	/** Token expiration time in seconds from now */
-	expires_in: number;
+	get clientMetadata(): OAuthClientMetadata {
+		return {
+			client_name: 'Obsidian Granola Importer',
+			redirect_uris: [REDIRECT_URL],
+			grant_types: ['authorization_code', 'refresh_token'],
+			response_types: ['code'],
+			token_endpoint_auth_method: 'none',
+		};
+	}
 
-	/** JWT ID token containing user information */
-	id_token: string;
-}
-
-/**
- * Configuration structure for Supabase authentication data.
- *
- * This interface mirrors the structure of the supabase.json file
- * created by the Granola desktop application. The file contains
- * OAuth tokens and metadata required for API access.
- *
- * @interface SupabaseConfig
- * @since 1.0.0
- */
-export interface SupabaseConfig {
-	/** Stringified JSON containing AWS Cognito OAuth tokens */
-	cognito_tokens: string;
-
-	/** Stringified JSON containing user profile information */
-	user_info: string;
-}
-
-/**
- * Handles authentication and credential management for Granola API access.
- *
- * This class is responsible for:
- * - Loading credentials from platform-specific configuration files
- * - Validating token format and expiration
- * - Providing bearer tokens for API requests
- * - Managing token lifecycle (future: refresh capability)
- *
- * The authentication flow relies on the Granola desktop application
- * to handle OAuth and store credentials in the appropriate location.
- *
- * @class GranolaAuth
- * @since 1.0.0
- *
- * @example
- * ```typescript
- * const auth = new GranolaAuth();
- * await auth.loadCredentials();
- * const token = auth.getBearerToken();
- * ```
- */
-export class GranolaAuth {
-	/**
-	 * Cached credentials loaded from the configuration file.
-	 * Null until credentials are successfully loaded and validated.
-	 * @private
-	 */
-	private credentials: GranolaCredentials | null = null;
-
-	/**
-	 * Base path for Granola configuration files.
-	 * Set dynamically based on the current platform.
-	 * @private
-	 */
-	private configBasePath: string = '';
-
-	/**
-	 * Loads and validates Granola credentials from the platform-specific config file.
-	 *
-	 * This method locates the supabase.json file created by the Granola desktop app,
-	 * reads the credential data, validates the token format and expiration,
-	 * and caches the credentials for subsequent API requests.
-	 *
-	 * Note: On mobile platforms, this will fail as Granola is a desktop-only application.
-	 * The plugin currently only supports desktop platforms.
-	 *
-	 * @async
-	 * @returns {Promise<GranolaCredentials>} The validated credentials
-	 * @throws {Error} If credentials file is missing, malformed, or contains invalid data
-	 *
-	 * @example
-	 * ```typescript
-	 * try {
-	 *   const credentials = await auth.loadCredentials();
-	 *   console.log('Credentials loaded successfully');
-	 * } catch (error) {
-	 *   console.error('Failed to load credentials:', error.message);
-	 * }
-	 * ```
-	 */
 	async loadCredentials(): Promise<GranolaCredentials> {
-		if (this.credentials) {
-			return this.credentials;
-		}
+		const tokens = await this.tokens();
 
-		// Check if running on a supported platform
-		if (Platform.isMobile) {
+		if (!tokens?.access_token) {
 			throw new Error(
-				'Granola Importer is not supported on mobile devices. ' +
-					'Granola is a desktop application and credentials are only available on desktop platforms.'
+				'Granola account is not connected. Start the Granola OAuth flow from the plugin settings or import command.'
 			);
 		}
 
-		const configPath = this.getSupabaseConfigPath();
+		this.validateTokens(tokens);
+		this.credentials = tokens;
 
-		try {
-			// Read credentials file from the user's home directory
-			// Note: This accesses files outside the vault, which requires Obsidian's
-			// file system APIs. On desktop, we use a workaround with fetch for local files.
-			const configData = await this.readConfigFile(configPath);
-			const config: SupabaseConfig = JSON.parse(configData);
-
-			// Parse the nested cognito_tokens JSON string
-			const cognitoTokens: CognitoTokens = JSON.parse(config.cognito_tokens);
-
-			this.validateCredentials(cognitoTokens);
-
-			// Convert expires_in (seconds from now) to expires_at (unix timestamp)
-			const expiresAt =
-				Math.floor(Date.now() / TIMESTAMP_CONVERSION_FACTOR) + cognitoTokens.expires_in;
-
-			this.credentials = {
-				access_token: cognitoTokens.access_token,
-				refresh_token: cognitoTokens.refresh_token,
-				token_type: cognitoTokens.token_type.toLowerCase(), // Normalize to lowercase
-				expires_at: expiresAt,
-			};
-
-			return this.credentials;
-		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-			throw new Error(`Failed to load Granola credentials: ${errorMessage}`);
-		}
+		return {
+			access_token: tokens.access_token,
+			refresh_token: tokens.refresh_token,
+			token_type: tokens.token_type.toLowerCase(),
+			expires_at: tokens.expires_at,
+		};
 	}
 
-	/**
-	 * Reads the configuration file from the file system.
-	 *
-	 * Uses a workaround to read files from outside the vault on desktop platforms.
-	 * This is necessary because Granola stores credentials in the user's home directory,
-	 * not within the Obsidian vault.
-	 *
-	 * @private
-	 * @param {string} path - Absolute path to the configuration file
-	 * @returns {Promise<string>} The file contents as a string
-	 * @throws {Error} If the file cannot be read
-	 */
-	private async readConfigFile(path: string): Promise<string> {
-		try {
-			// Use Node.js fs module directly on desktop
-			// This is a workaround since Obsidian's DataAdapter is vault-scoped
-			return readFileSync(path, 'utf-8');
-		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-			throw new Error(
-				`Cannot read Granola configuration file at ${path}. ` +
-					'Please ensure Granola is installed and you are logged in. ' +
-					`Error: ${errorMessage}`
-			);
-		}
+	async tokens(): Promise<GranolaOAuthTokens | undefined> {
+		const data = await this.getData();
+		this.credentials = data.oauthTokens ?? null;
+		return data.oauthTokens;
 	}
 
-	/**
-	 * Determines the platform-specific path to the Granola configuration file.
-	 *
-	 * The Granola desktop application stores OAuth credentials in different
-	 * locations depending on the operating system:
-	 * - macOS: ~/Library/Application Support/Granola/supabase.json
-	 * - Windows: %APPDATA%/Granola/supabase.json
-	 * - Linux: ~/.config/Granola/supabase.json
-	 *
-	 * @private
-	 * @returns {string} The absolute path to the configuration file
-	 * @throws {Error} If the current platform is not supported
-	 *
-	 * @example
-	 * ```typescript
-	 * const configPath = this.getSupabaseConfigPath();
-	 * // Returns: "/home/user/.config/Granola/supabase.json" on Linux
-	 * ```
-	 */
-	private getSupabaseConfigPath(): string {
-		// Use Node.js modules to determine paths
-		// This works on Obsidian desktop but not mobile
-		const platformType = osPlatform();
-		const homeDir = homedir();
+	async saveTokens(tokens: OAuthTokens): Promise<void> {
+		const nowSeconds = Math.floor(Date.now() / TIMESTAMP_CONVERSION_FACTOR);
+		const storedTokens: GranolaOAuthTokens = {
+			...tokens,
+			obtained_at: nowSeconds,
+			expires_at: tokens.expires_in ? nowSeconds + tokens.expires_in : undefined,
+		};
 
-		switch (platformType) {
-			case 'darwin': // macOS
-				return join(homeDir, 'Library', 'Application Support', 'Granola', 'supabase.json');
-			case 'win32': // Windows
-				return join(homeDir, 'AppData', 'Roaming', 'Granola', 'supabase.json');
-			case 'linux': // Linux
-				return join(homeDir, '.config', 'Granola', 'supabase.json');
-			default:
-				throw new Error(`Unsupported platform: ${platformType}`);
-		}
+		await this.updateData(data => {
+			data.oauthTokens = storedTokens;
+		});
+		this.credentials = storedTokens;
 	}
 
-	/**
-	 * Validates the structure and content of loaded credentials.
-	 *
-	 * Performs comprehensive validation including:
-	 * - Required field presence check
-	 * - Token type verification (must be "bearer" case-insensitive)
-	 * - JWT token format validation using regex
-	 * - Token expiration check using expires_in field
-	 *
-	 * @private
-	 * @param {CognitoTokens} tokens - The cognito tokens object to validate
-	 * @throws {Error} If any validation check fails
-	 *
-	 * @example
-	 * ```typescript
-	 * try {
-	 *   this.validateCredentials(tokens);
-	 *   console.log('Credentials are valid');
-	 * } catch (error) {
-	 *   console.error('Invalid credentials:', error.message);
-	 * }
-	 * ```
-	 */
-	private validateCredentials(tokens: CognitoTokens): void {
-		const required: (keyof CognitoTokens)[] = [
-			'access_token',
-			'refresh_token',
-			'token_type',
-			'expires_in',
-		];
+	async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
+		const data = await this.getData();
+		return data.oauthClientInfo;
+	}
 
-		for (const field of required) {
-			if (!tokens[field]) {
-				throw new Error(`Missing required field: ${field}`);
+	async saveClientInformation(info: OAuthClientInformationMixed): Promise<void> {
+		await this.updateData(data => {
+			data.oauthClientInfo = info;
+		});
+	}
+
+	async redirectToAuthorization(url: URL): Promise<void> {
+		const target = url.toString();
+		if (this.storage.openUrl) {
+			this.storage.openUrl(target);
+			return;
+		}
+
+		window.open(target);
+	}
+
+	async saveCodeVerifier(verifier: string): Promise<void> {
+		await this.updateData(data => {
+			data.oauthCodeVerifier = verifier;
+		});
+	}
+
+	async codeVerifier(): Promise<string> {
+		const data = await this.getData();
+		if (!data.oauthCodeVerifier) {
+			throw new Error('Missing OAuth code verifier. Please restart Granola authorization.');
+		}
+		return data.oauthCodeVerifier;
+	}
+
+	async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
+		await this.updateData(data => {
+			data.oauthDiscoveryState = state;
+		});
+	}
+
+	async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
+		const data = await this.getData();
+		return data.oauthDiscoveryState;
+	}
+
+	async invalidateCredentials(
+		scope: 'all' | 'client' | 'tokens' | 'verifier' | 'discovery'
+	): Promise<void> {
+		await this.updateData(data => {
+			if (scope === 'all' || scope === 'tokens') {
+				delete data.oauthTokens;
+				this.credentials = null;
 			}
-		}
-
-		if (tokens.token_type.toLowerCase() !== 'bearer') {
-			throw new Error(`Invalid token type: ${tokens.token_type}`);
-		}
-
-		// Enhanced JWT format validation - should have exactly 3 non-empty parts
-		const tokenParts = tokens.access_token.split('.');
-		if (tokenParts.length !== JWT_PARTS_COUNT || tokenParts.some(part => part.length === 0)) {
-			throw new Error('Invalid token format');
-		}
-
-		// Check if token will expire soon (expires_in is in seconds)
-		if (tokens.expires_in <= 0) {
-			throw new Error('Access token has expired');
-		}
+			if (scope === 'all' || scope === 'client') {
+				delete data.oauthClientInfo;
+			}
+			if (scope === 'all' || scope === 'verifier') {
+				delete data.oauthCodeVerifier;
+			}
+			if (scope === 'all' || scope === 'discovery') {
+				delete data.oauthDiscoveryState;
+			}
+		});
 	}
 
-	/**
-	 * Retrieves the access token for use in API Authorization headers.
-	 *
-	 * This method returns the raw JWT access token that should be used
-	 * with the "Bearer" authentication scheme in HTTP requests.
-	 *
-	 * @returns {string} The JWT access token
-	 * @throws {Error} If credentials have not been loaded
-	 *
-	 * @example
-	 * ```typescript
-	 * const token = auth.getBearerToken();
-	 * const headers = {
-	 *   'Authorization': `Bearer ${token}`,
-	 *   'Content-Type': 'application/json'
-	 * };
-	 * ```
-	 */
 	getBearerToken(): string {
-		if (!this.credentials) {
+		if (!this.credentials?.access_token) {
 			throw new Error('Credentials not loaded');
 		}
-
 		return this.credentials.access_token;
 	}
 
-	/**
-	 * Checks if the current access token has expired.
-	 *
-	 * Compares the token's expiration timestamp against the current time
-	 * to determine if the token needs to be refreshed before making API calls.
-	 *
-	 * @returns {boolean} True if token is expired or not loaded, false if valid
-	 *
-	 * @example
-	 * ```typescript
-	 * if (auth.isTokenExpired()) {
-	 *   console.log('Token needs refresh');
-	 *   // In future: await auth.refreshToken();
-	 * }
-	 * ```
-	 */
 	isTokenExpired(): boolean {
-		if (!this.credentials) {
-			return true;
+		if (!this.credentials?.expires_at) {
+			return !this.credentials;
 		}
 
-		return Date.now() > this.credentials.expires_at * TIMESTAMP_CONVERSION_FACTOR;
+		const expiresAt =
+			(this.credentials.expires_at - TOKEN_EXPIRY_SKEW_SECONDS) * TIMESTAMP_CONVERSION_FACTOR;
+		return Date.now() >= expiresAt;
 	}
 
-	/**
-	 * Refreshes an expired access token using the stored refresh token.
-	 *
-	 * @deprecated This method is not yet implemented. Users must re-authenticate
-	 * through the Granola desktop application when tokens expire.
-	 *
-	 * Future implementation will use the refresh_token to obtain new credentials
-	 * from the Granola API without requiring user intervention.
-	 *
-	 * @async
-	 * @returns {Promise<void>} Resolves when token refresh completes
-	 * @throws {Error} Currently always throws as refresh is not implemented
-	 *
-	 * @example
-	 * ```typescript
-	 * try {
-	 *   await auth.refreshToken();
-	 * } catch (error) {
-	 *   console.log('Refresh not available, please re-authenticate');
-	 * }
-	 * ```
-	 */
-	refreshToken(): void {
-		if (!this.credentials?.refresh_token) {
+	async refreshToken(): Promise<void> {
+		const tokens = await this.tokens();
+		if (!tokens?.refresh_token) {
 			throw new Error('No refresh token available');
 		}
 
-		try {
-			// Note: This would require implementing the actual refresh endpoint
-			// For now, we'll throw an informative error directing users to re-authenticate
-			throw new Error(
-				'Token refresh not yet implemented. Please re-authenticate in the Granola app.'
-			);
+		const result = await runOAuthFlow(this, {
+			serverUrl: MCP_SERVER_URL,
+			fetchFn: nodeFetch,
+		});
 
-			// Future implementation would look like:
-			// const response = await fetch('https://api.granola.ai/auth/refresh', {
-			//     method: 'POST',
-			//     headers: { 'Content-Type': 'application/json' },
-			//     body: JSON.stringify({ refresh_token: this.credentials.refresh_token })
-			// });
-			// const newTokens = await response.json();
-			// this.credentials = { ...this.credentials, ...newTokens };
-		} catch (error) {
-			this.credentials = null; // Clear invalid credentials
-			const errorMessage = error instanceof Error ? error.message : 'Token refresh failed';
-			throw new Error(`Token refresh failed: ${errorMessage}`);
+		if (result === 'REDIRECT') {
+			throw new Error('Granola authorization required. Complete the browser OAuth flow.');
 		}
 	}
 
-	/**
-	 * Clears cached credentials from memory.
-	 *
-	 * This method removes stored credentials, typically called when
-	 * authentication fails or tokens become invalid. Does not affect
-	 * the credential file on disk.
-	 *
-	 * @returns {void}
-	 *
-	 * @example
-	 * ```typescript
-	 * auth.clearCredentials();
-	 * console.log('Credentials cleared from memory');
-	 * ```
-	 */
-	clearCredentials(): void {
+	async clearCredentials(): Promise<void> {
 		this.credentials = null;
+		await this.invalidateCredentials('all');
 	}
 
-	/**
-	 * Checks if valid, non-expired credentials are currently loaded.
-	 *
-	 * This is a convenience method that combines credential existence
-	 * and expiration checks to determine if the auth manager is ready
-	 * for API requests.
-	 *
-	 * @returns {boolean} True if credentials are loaded and not expired
-	 *
-	 * @example
-	 * ```typescript
-	 * if (auth.hasValidCredentials()) {
-	 *   // Safe to make API calls
-	 *   const documents = await api.getDocuments();
-	 * } else {
-	 *   // Need to load/refresh credentials first
-	 *   await auth.loadCredentials();
-	 * }
-	 * ```
-	 */
 	hasValidCredentials(): boolean {
-		return this.credentials !== null && !this.isTokenExpired();
+		return !!this.credentials?.access_token && !this.isTokenExpired();
+	}
+
+	private validateTokens(tokens: GranolaOAuthTokens): void {
+		if (!tokens.access_token) {
+			throw new Error('Missing required field: access_token');
+		}
+		if (!tokens.token_type) {
+			throw new Error('Missing required field: token_type');
+		}
+		if (tokens.token_type.toLowerCase() !== 'bearer') {
+			throw new Error(`Invalid token type: ${tokens.token_type}`);
+		}
+	}
+
+	private async getData(): Promise<GranolaAuthData & Record<string, unknown>> {
+		this.dataCache = { ...((await this.storage.getData()) ?? {}) };
+		return this.dataCache;
+	}
+
+	private async updateData(
+		mutator: (data: GranolaAuthData & Record<string, unknown>) => void
+	): Promise<void> {
+		const data = { ...(await this.getData()) };
+		mutator(data);
+		this.dataCache = data;
+		await this.storage.saveData(data);
 	}
 }

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -389,7 +389,7 @@ export class ProseMirrorConverter {
 			);
 
 			// Create a helpful placeholder instead of failing completely
-			markdown = `# ${decodeHtmlEntities(doc.title)}\n\n*This document appears to have no extractable content from the Granola API.*\n\n*Possible causes:*\n- Content exists in Granola but wasn't included in the API response\n- Document was created but never had content added\n- Sync issue between Granola desktop app and API\n\n*To fix: Check the original document in Granola and manually copy content if needed.*\n\n---\n*Document ID: ${doc.id}*\n*Created: ${doc.created_at}*\n*Updated: ${doc.updated_at}*`;
+			markdown = `# ${decodeHtmlEntities(doc.title)}\n\n*This document appears to have no extractable content from Granola MCP.*\n\n*Possible causes:*\n- Content exists in Granola but wasn't included in the MCP response\n- Document was created but never had content added\n- Granola MCP only returned meeting metadata for this note\n\n*To fix: Check the original document in Granola and manually copy content if needed.*\n\n---\n*Document ID: ${doc.id}*\n*Created: ${doc.created_at}*\n*Updated: ${doc.updated_at}*`;
 		}
 
 		// Process action items if enabled

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,0 +1,151 @@
+import { request as httpRequest, IncomingMessage } from 'http';
+import { request as httpsRequest } from 'https';
+
+const MAX_REDIRECTS = 5;
+
+/**
+ * Fetch implementation backed by Node's HTTP modules.
+ *
+ * Obsidian's browser fetch can enforce CORS for remote MCP/OAuth requests; the
+ * MCP SDK accepts a fetch-compatible function, so use Node networking instead.
+ */
+export function nodeFetch(input: string | URL, init?: RequestInit): Promise<Response> {
+	return doFetch(input, init, 0);
+}
+
+function doFetch(
+	input: string | URL,
+	init: RequestInit | undefined,
+	redirectCount: number
+): Promise<Response> {
+	return new Promise((resolve, reject) => {
+		const url = typeof input === 'string' ? new URL(input) : input;
+		const request = url.protocol === 'https:' ? httpsRequest : httpRequest;
+		const headers = new Headers(init?.headers);
+		const body = toBodyBuffer(init?.body);
+
+		if (body && !headers.has('content-length')) {
+			headers.set('content-length', String(body.length));
+		}
+
+		const req = request(
+			{
+				hostname: url.hostname,
+				port: url.port || undefined,
+				path: `${url.pathname}${url.search}`,
+				method: init?.method || 'GET',
+				headers: toRequestHeaders(headers),
+			},
+			(res: IncomingMessage) => {
+				if (
+					res.statusCode &&
+					res.statusCode >= 300 &&
+					res.statusCode < 400 &&
+					res.headers.location &&
+					redirectCount < MAX_REDIRECTS
+				) {
+					const redirectUrl = new URL(res.headers.location, url);
+					res.resume();
+					doFetch(redirectUrl, init, redirectCount + 1).then(resolve, reject);
+					return;
+				}
+
+				resolve(
+					new Response(toWebReadableStream(res), {
+						status: res.statusCode || 200,
+						statusText: res.statusMessage || '',
+						headers: toResponseHeaders(res),
+					})
+				);
+			}
+		);
+
+		req.on('error', reject);
+
+		if (init?.signal) {
+			if (init.signal.aborted) {
+				req.destroy();
+				reject(new DOMException('The operation was aborted', 'AbortError'));
+				return;
+			}
+
+			init.signal.addEventListener('abort', () => {
+				req.destroy();
+				reject(new DOMException('The operation was aborted', 'AbortError'));
+			});
+		}
+
+		if (body) {
+			req.write(body);
+		}
+
+		req.end();
+	});
+}
+
+function toRequestHeaders(headers: Headers): Record<string, string> {
+	const result: Record<string, string> = {};
+	headers.forEach((value, key) => {
+		result[key] = value;
+	});
+	return result;
+}
+
+function toBodyBuffer(body: BodyInit | null | undefined): Buffer | undefined {
+	if (body == null) {
+		return undefined;
+	}
+
+	if (typeof body === 'string') {
+		return Buffer.from(body, 'utf-8');
+	}
+
+	if (body instanceof URLSearchParams) {
+		return Buffer.from(body.toString(), 'utf-8');
+	}
+
+	if (body instanceof ArrayBuffer) {
+		return Buffer.from(body);
+	}
+
+	if (ArrayBuffer.isView(body)) {
+		return Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+	}
+
+	return undefined;
+}
+
+function toResponseHeaders(res: IncomingMessage): Headers {
+	const headers = new Headers();
+
+	for (const [key, value] of Object.entries(res.headers)) {
+		if (Array.isArray(value)) {
+			for (const item of value) {
+				headers.append(key, item);
+			}
+		} else if (value !== undefined) {
+			headers.set(key, value);
+		}
+	}
+
+	return headers;
+}
+
+function toWebReadableStream(res: IncomingMessage): ReadableStream<Uint8Array> {
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			res.on('data', (chunk: Buffer) => {
+				controller.enqueue(new Uint8Array(chunk));
+			});
+			res.on('end', () => {
+				controller.close();
+			});
+			res.on('error', error => {
+				controller.error(error);
+			});
+		},
+		cancel() {
+			res.destroy();
+		},
+	});
+}

--- a/src/services/duplicate-detector.ts
+++ b/src/services/duplicate-detector.ts
@@ -375,7 +375,7 @@ export class DuplicateDetector {
 	 * @returns {string} Content without frontmatter
 	 */
 	private extractContentAfterFrontmatter(content: string): string {
-		const frontmatterMatch = content.match(/^---\n[\s\S]*?\n---\n(.*)$/s);
+		const frontmatterMatch = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
 		return frontmatterMatch ? frontmatterMatch[1] : content;
 	}
 

--- a/src/services/import-manager.ts
+++ b/src/services/import-manager.ts
@@ -798,7 +798,7 @@ export class SelectiveImportManager {
 		if (!folder) {
 			try {
 				await this.vault.createFolder(folderPath);
-			} catch (error) {
+			} catch {
 				// Folder might already exist or parent folders need to be created
 				const parts = folderPath.split('/');
 				let currentPath = '';
@@ -808,7 +808,7 @@ export class SelectiveImportManager {
 					if (!existing) {
 						try {
 							await this.vault.createFolder(currentPath);
-						} catch (e) {
+						} catch {
 							// Ignore if folder already exists
 						}
 					}
@@ -1027,7 +1027,7 @@ export class SelectiveImportManager {
 	 * @returns {string} Content without frontmatter
 	 */
 	private extractContentAfterFrontmatter(content: string): string {
-		const frontmatterMatch = content.match(/^---\n[\s\S]*?\n---\n(.*)$/s);
+		const frontmatterMatch = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
 		return frontmatterMatch ? frontmatterMatch[1] : content;
 	}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -446,9 +446,8 @@ export class GranolaSettingTab extends PluginSettingTab {
 		});
 
 		try {
-			// Create a temporary API instance for testing
-			const auth = this.plugin.auth;
-			await auth.loadCredentials();
+			// Connect through MCP. If OAuth is needed, this starts the browser flow.
+			await this.plugin.api.loadCredentials();
 
 			// Try to fetch a small number of documents to test the connection
 			const response = await this.plugin.api.getDocuments({ limit: 1, offset: 0 });

--- a/src/ui/document-selection-modal.ts
+++ b/src/ui/document-selection-modal.ts
@@ -1152,7 +1152,7 @@ export class DocumentSelectionModal extends Modal {
 		}
 		try {
 			return new Date(timestamp).toISOString();
-		} catch (error) {
+		} catch {
 			return 'Unknown';
 		}
 	}

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -87,6 +87,10 @@ export class Plugin {
 	onunload() {}
 	addCommand(command: any) {}
 	addSettingTab(tab: any) {}
+	registerObsidianProtocolHandler(
+		action: string,
+		handler: (params: Record<string, string>) => void
+	) {}
 	addRibbonIcon(icon: string, title: string, callback: () => void) {
 		// Mock implementation - return a mock HTMLElement
 		const mockElement = {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import { ReadableStream, TransformStream } from 'stream/web';
 
 // Define development constants for test environment
 declare global {
@@ -7,6 +8,28 @@ declare global {
 }
 global.__DEV__ = true;
 global.DEBUG = true;
+
+if (!global.TransformStream) {
+	global.TransformStream = TransformStream as unknown as typeof global.TransformStream;
+}
+if (!global.ReadableStream) {
+	global.ReadableStream = ReadableStream as unknown as typeof global.ReadableStream;
+}
+if (!global.Response) {
+	global.Response = class TestResponse {
+		body: BodyInit | null;
+		status: number;
+		statusText: string;
+		headers: Headers;
+
+		constructor(body: BodyInit | null = null, init: ResponseInit = {}) {
+			this.body = body;
+			this.status = init.status ?? 200;
+			this.statusText = init.statusText ?? '';
+			this.headers = new Headers(init.headers);
+		}
+	} as unknown as typeof Response;
+}
 
 // Enhanced DOM environment setup for complex UI testing
 import './helpers/dom-test-utils';
@@ -267,21 +290,14 @@ Object.defineProperty(window, 'sessionStorage', {
 	writable: true,
 });
 
-// Mock URL and URLSearchParams for modern web APIs
-global.URL = jest.fn().mockImplementation((url, base) => ({
-	href: url,
-	origin: 'http://localhost:3000',
-	protocol: 'http:',
-	host: 'localhost:3000',
-	hostname: 'localhost',
-	port: '3000',
-	pathname: new URL(url, base || 'http://localhost:3000').pathname,
-	search: new URL(url, base || 'http://localhost:3000').search,
-	hash: new URL(url, base || 'http://localhost:3000').hash,
-	searchParams: new URLSearchParams(new URL(url, base || 'http://localhost:3000').search),
-}));
+// Mock URL constructor while delegating parsing to the native implementation.
+const NativeURL = global.URL;
+const NativeURLSearchParams = global.URLSearchParams;
+global.URL = jest.fn().mockImplementation((url, base) => {
+	return new NativeURL(url, base || 'http://localhost:3000');
+}) as unknown as typeof URL;
 
-global.URLSearchParams = URLSearchParams;
+global.URLSearchParams = NativeURLSearchParams;
 
 // Mock Clipboard API for testing copy/paste functionality
 Object.assign(navigator, {

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -1,783 +1,182 @@
-import { jest } from '@jest/globals';
 import { GranolaAPI } from '../../src/api';
 import { GranolaAuth } from '../../src/auth';
-import { createMockRequestUrl, mockDocument, mockApiResponse } from '../helpers';
-import { requestUrl } from 'obsidian';
 
-// Mock requestUrl from obsidian
-jest.mock('obsidian', () => ({
-	...jest.requireActual('obsidian'),
-	requestUrl: jest.fn(),
+const mockConnect = jest.fn();
+const mockClose = jest.fn();
+const mockListTools = jest.fn();
+const mockCallTool = jest.fn();
+const mockFinishAuth = jest.fn();
+
+jest.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+	Client: jest.fn().mockImplementation(() => ({
+		connect: mockConnect,
+		close: mockClose,
+		listTools: mockListTools,
+		callTool: mockCallTool,
+	})),
 }));
 
+jest.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+	StreamableHTTPClientTransport: jest.fn().mockImplementation(() => ({
+		finishAuth: mockFinishAuth,
+	})),
+}));
+
+const listResponse = `
+<meeting id="meeting-1" title="Alpha &amp; Beta" date="Mar 3, 2026 3:00 PM">
+	<known_participants>Alex Smith (note creator) from OpenAI &lt;alex@example.com&gt;, Sam Lee from Acme &lt;sam@acme.com&gt;</known_participants>
+</meeting>
+<meeting id="meeting-2" title="Planning" date="Mar 4, 2026 10:15 AM">
+	<known_participants>Riley Jones from Example &lt;riley@example.com&gt;</known_participants>
+</meeting>`;
+
+const detailsResponse = `
+<meeting id="meeting-1" title="Alpha &amp; Beta" date="Mar 3, 2026 3:00 PM">
+	<known_participants>Alex Smith (note creator) from OpenAI &lt;alex@example.com&gt;, Sam Lee from Acme &lt;sam@acme.com&gt;</known_participants>
+	<private_notes>Private **notes**</private_notes>
+	<summary>- Summary item</summary>
+</meeting>
+<meeting id="meeting-2" title="Planning" date="Mar 4, 2026 10:15 AM">
+	<known_participants>Riley Jones from Example &lt;riley@example.com&gt;</known_participants>
+	<summary>Planning summary</summary>
+</meeting>`;
+
+function toolText(text: string, isError = false) {
+	return {
+		content: [{ type: 'text', text }],
+		isError,
+	};
+}
+
 describe('GranolaAPI', () => {
+	let auth: GranolaAuth;
 	let api: GranolaAPI;
-	let mockAuth: jest.Mocked<GranolaAuth>;
 
-	beforeEach(() => {
-		mockAuth = {
-			getBearerToken: jest.fn().mockReturnValue('test-token'),
-			loadCredentials: jest.fn(),
-			isTokenExpired: jest.fn().mockReturnValue(false),
-			hasValidCredentials: jest.fn().mockReturnValue(true),
-			clearCredentials: jest.fn(),
-			refreshToken: jest.fn(),
-		} as any;
-
-		api = new GranolaAPI(mockAuth);
+	beforeEach(async () => {
 		jest.clearAllMocks();
-	});
 
-	describe('constructor', () => {
-		it('should create API instance with auth', () => {
-			expect(api).toBeInstanceOf(GranolaAPI);
+		auth = new GranolaAuth();
+		await auth.saveTokens({
+			access_token: 'access-token',
+			refresh_token: 'refresh-token',
+			token_type: 'Bearer',
 		});
+		api = new GranolaAPI(auth);
 
-		it('should handle invalid package.json format', () => {
-			// This test verifies the error handling for invalid package.json format
-			// The actual error path is tested by mocking filesystem at module load time
-			const testApi = new GranolaAPI(mockAuth);
-			// If package.json is invalid, fallback should be used
-			expect(testApi.userAgent).toMatch(/obsidian-granola-importer/);
+		mockConnect.mockResolvedValue(undefined);
+		mockClose.mockResolvedValue(undefined);
+		mockFinishAuth.mockResolvedValue(undefined);
+		mockListTools.mockResolvedValue({
+			tools: [
+				{ name: 'list_meetings', inputSchema: { type: 'object' } },
+				{ name: 'get_meetings', inputSchema: { type: 'object' } },
+			],
 		});
-
-		it('should handle missing package.json file', () => {
-			// This test verifies the fallback behavior when package.json is missing
-			const testApi = new GranolaAPI(mockAuth);
-			expect(testApi.userAgent).toMatch(/obsidian-granola-importer/);
-		});
-
-		it('should fallback to static version on file system error', () => {
-			// This test verifies the fallback behavior on filesystem errors
-			const testApi = new GranolaAPI(mockAuth);
-			expect(testApi.userAgent).toMatch(/obsidian-granola-importer/);
-		});
-	});
-
-	describe('loadCredentials', () => {
-		it('should call auth.loadCredentials', async () => {
-			await api.loadCredentials();
-			expect(mockAuth.loadCredentials).toHaveBeenCalled();
-		});
-
-		it('should propagate auth errors', async () => {
-			const authError = new Error('Failed to load credentials');
-			mockAuth.loadCredentials.mockRejectedValue(authError);
-
-			await expect(api.loadCredentials()).rejects.toThrow('Failed to load credentials');
+		mockCallTool.mockImplementation(({ name }) => {
+			if (name === 'list_meetings') {
+				return Promise.resolve(toolText(listResponse));
+			}
+			if (name === 'get_meetings') {
+				return Promise.resolve(toolText(detailsResponse));
+			}
+			return Promise.resolve(toolText('', true));
 		});
 	});
 
-	describe('getDocuments', () => {
-		it('should fetch documents with default parameters', async () => {
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 200,
-				json: mockApiResponse,
-				text: JSON.stringify(mockApiResponse),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
+	it('connects to the Granola MCP server and discovers tools', async () => {
+		await api.loadCredentials();
 
-			const result = await api.getDocuments();
-
-			expect(requestUrl).toHaveBeenCalledWith({
-				url: 'https://api.granola.ai/v2/get-documents',
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					Authorization: 'Bearer test-token',
-					'User-Agent': 'obsidian-granola-importer/1.0.0',
-				},
-				body: JSON.stringify({
-					limit: 100,
-					offset: 0,
-					include_last_viewed_panel: true,
-				}),
-				throw: false,
-			});
-
-			expect(result).toEqual(mockApiResponse);
-		});
-
-		it('should fetch documents with custom parameters', async () => {
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 200,
-				json: mockApiResponse,
-				text: JSON.stringify(mockApiResponse),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			await api.getDocuments({ limit: 50, offset: 25 });
-
-			expect(requestUrl).toHaveBeenCalledWith(
-				expect.objectContaining({
-					url: 'https://api.granola.ai/v2/get-documents',
-					body: JSON.stringify({
-						limit: 50,
-						offset: 25,
-						include_last_viewed_panel: true,
-					}),
-				})
-			);
-		});
-
-		it('should throw error for rate limit (429)', async () => {
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 429,
-				json: {},
-				text: '',
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			await expect(api.getDocuments()).rejects.toThrow('Rate limit exceeded');
-		});
-
-		it('should throw error for other HTTP errors', async () => {
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 500,
-				json: {},
-				text: '',
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			await expect(api.getDocuments()).rejects.toThrow('API request failed: 500');
-		});
-
-		it('should get bearer token from auth', async () => {
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 200,
-				json: mockApiResponse,
-				text: JSON.stringify(mockApiResponse),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			await api.getDocuments();
-
-			expect(mockAuth.getBearerToken).toHaveBeenCalled();
-		});
+		expect(mockConnect).toHaveBeenCalledTimes(1);
+		expect(mockListTools).toHaveBeenCalledTimes(1);
+		expect(api.isConnected).toBe(true);
+		await expect(api.getAvailableTools()).resolves.toEqual([
+			{ name: 'list_meetings', description: undefined, inputSchema: { type: 'object' } },
+			{ name: 'get_meetings', description: undefined, inputSchema: { type: 'object' } },
+		]);
 	});
 
-	describe('getAllDocuments', () => {
-		it('should fetch all documents in single request', async () => {
-			const apiResponse = {
-				docs: [mockDocument, { ...mockDocument, id: 'doc-2' }],
-				deleted: ['deleted-doc-1'],
-			};
+	it('lists and fetches meetings through MCP tools', async () => {
+		const response = await api.getDocuments({ limit: 1, offset: 0 });
 
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 200,
-				json: apiResponse,
-				text: JSON.stringify(apiResponse),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			const result = await api.getAllDocuments();
-
-			expect(result).toHaveLength(2);
-			expect(result[0].id).toBe(mockDocument.id);
-			expect(result[1].id).toBe('doc-2');
-			expect(requestUrl).toHaveBeenCalledTimes(1);
+		expect(mockCallTool).toHaveBeenNthCalledWith(1, {
+			name: 'list_meetings',
+			arguments: { time_range: 'last_30_days' },
 		});
-
-		it('should throw error when API returns unexpected response format', async () => {
-			const invalidResponse = {
-				documents: [mockDocument], // Wrong field name
-				deleted: [],
-			};
-
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 200,
-				json: invalidResponse,
-				text: JSON.stringify(invalidResponse),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-
-			await expect(api.getAllDocuments()).rejects.toThrow(
-				'API returned unexpected response format'
-			);
-			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				'Unexpected API response format:',
-				invalidResponse
-			);
-
-			consoleErrorSpy.mockRestore();
+		expect(mockCallTool).toHaveBeenNthCalledWith(2, {
+			name: 'get_meetings',
+			arguments: { meeting_ids: ['meeting-1'] },
 		});
-
-		it('should throw error when docs field is missing', async () => {
-			const invalidResponse = {
-				deleted: [],
-			};
-
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 200,
-				json: invalidResponse,
-				text: JSON.stringify(invalidResponse),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-
-			await expect(api.getAllDocuments()).rejects.toThrow(
-				'API returned unexpected response format'
-			);
-			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				'Unexpected API response format:',
-				invalidResponse
-			);
-
-			consoleErrorSpy.mockRestore();
+		expect(response.deleted).toEqual([]);
+		expect(response.docs).toHaveLength(1);
+		expect(response.docs[0]).toMatchObject({
+			id: 'meeting-1',
+			title: 'Alpha & Beta',
+			notes_markdown: '## Notes\n\nPrivate **notes**\n\n## Summary\n\n- Summary item',
+			notes_plain: 'Notes Private notes Summary Summary item',
+			user_id: '',
 		});
-
-		it('should throw error when docs field is not an array', async () => {
-			const invalidResponse = {
-				docs: 'not an array',
-				deleted: [],
-			};
-
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 200,
-				json: invalidResponse,
-				text: JSON.stringify(invalidResponse),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-
-			await expect(api.getAllDocuments()).rejects.toThrow(
-				'API returned unexpected response format'
-			);
-			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				'Unexpected API response format:',
-				invalidResponse
-			);
-
-			consoleErrorSpy.mockRestore();
-		});
-
-		it('should handle single document response', async () => {
-			const singleDocResponse = {
-				docs: [mockDocument],
-				deleted: [],
-			};
-
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 200,
-				json: singleDocResponse,
-				text: JSON.stringify(singleDocResponse),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			const result = await api.getAllDocuments();
-
-			expect(result).toHaveLength(1);
-			expect(result[0]).toEqual(mockDocument);
-			expect(requestUrl).toHaveBeenCalledTimes(1);
-		});
-
-		it('should handle empty response', async () => {
-			const emptyResponse = {
-				docs: [],
-				deleted: [],
-			};
-
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 200,
-				json: emptyResponse,
-				text: JSON.stringify(emptyResponse),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			const result = await api.getAllDocuments();
-
-			expect(result).toHaveLength(0);
-			expect(requestUrl).toHaveBeenCalledTimes(1);
-		});
-
-		it('should not apply rate limiting for single request', async () => {
-			const apiResponse = {
-				docs: [mockDocument, { ...mockDocument, id: 'doc-2' }],
-				deleted: [],
-			};
-
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 200,
-				json: apiResponse,
-				text: JSON.stringify(apiResponse),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			await api.getAllDocuments();
-
-			// Single request should not require any delay/retry
-			expect(requestUrl).toHaveBeenCalledTimes(1);
-		});
-	});
-
-	describe('makeRequest', () => {
-		it('should make successful request on first try', async () => {
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 200,
-				json: {},
-				text: '',
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			const result = await (api as any).makeRequest('/test', {
-				method: 'GET',
-				headers: { Authorization: 'Bearer test' },
-			});
-
-			expect(result.status).toBe(200);
-			expect(requestUrl).toHaveBeenCalledTimes(1);
-			expect(requestUrl).toHaveBeenCalledWith({
-				url: 'https://api.granola.ai/v2/test',
-				method: 'GET',
-				headers: { Authorization: 'Bearer test' },
-				throw: false,
-			});
-		});
-
-		it('should retry on rate limit (429) with exponential backoff', async () => {
-			const mockResponse = { ok: true, status: 200 };
-			(requestUrl as jest.MockedFunction<typeof requestUrl>)
-				.mockResolvedValueOnce({
-					status: 429,
-					json: {},
-					text: '',
-					headers: {},
-					arrayBuffer: new ArrayBuffer(0),
-				})
-				.mockResolvedValueOnce({
-					status: 429,
-					json: {},
-					text: '',
-					headers: {},
-					arrayBuffer: new ArrayBuffer(0),
-				})
-				.mockResolvedValueOnce({
-					status: 200,
-					json: mockResponse,
-					text: JSON.stringify(mockResponse),
-					headers: {},
-					arrayBuffer: new ArrayBuffer(0),
-				});
-
-			const result = await (api as any).makeRequest('/test', {
-				method: 'GET',
-				headers: {},
-			});
-
-			// Should have retried twice before succeeding
-			expect(requestUrl).toHaveBeenCalledTimes(3);
-		});
-
-		it('should return 429 response on final attempt', async () => {
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 429,
-				json: {},
-				text: '',
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			const result = await (api as any).makeRequest('/test', {
-				method: 'GET',
-				headers: {},
-			});
-
-			expect(result.status).toBe(429);
-			// Should try 3 times and return 429 on final attempt
-			expect(requestUrl).toHaveBeenCalledTimes(3);
-		});
-
-		it('should retry on network errors', async () => {
-			const networkError = new Error('Network error');
-			const mockResponse = { ok: true, status: 200 };
-			(requestUrl as jest.MockedFunction<typeof requestUrl>)
-				.mockRejectedValueOnce(networkError)
-				.mockRejectedValueOnce(networkError)
-				.mockResolvedValueOnce({
-					status: 200,
-					json: mockResponse,
-					text: JSON.stringify(mockResponse),
-					headers: {},
-					arrayBuffer: new ArrayBuffer(0),
-				});
-
-			const result = await (api as any).makeRequest('/test', {
-				method: 'GET',
-				headers: {},
-			});
-
-			// Should have retried twice before succeeding
-			expect(requestUrl).toHaveBeenCalledTimes(3);
-		});
-
-		it('should throw error after max retries on network failure', async () => {
-			const networkError = new Error('Network error');
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockRejectedValue(networkError);
-
-			await expect(
-				(api as any).makeRequest('/test', {
-					method: 'GET',
-					headers: {},
-				})
-			).rejects.toThrow('Network request failed after 3 attempts: Network error');
-
-			// Should have tried 3 times
-			expect(requestUrl).toHaveBeenCalledTimes(3);
-		});
-
-		it('should handle non-Error exceptions', async () => {
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockRejectedValue(
-				'string error'
-			);
-
-			await expect(
-				(api as any).makeRequest('/test', {
-					method: 'GET',
-					headers: {},
-				})
-			).rejects.toThrow('Network request failed after 3 attempts: Unknown error');
-		});
-	});
-
-	describe('error handling', () => {
-		it('should preserve error types from auth module', async () => {
-			mockAuth.getBearerToken.mockImplementation(() => {
-				throw new Error('Credentials not loaded');
-			});
-
-			await expect(api.getDocuments()).rejects.toThrow('Credentials not loaded');
-		});
-	});
-
-	describe('integration scenarios', () => {
-		it('should handle large document collections', async () => {
-			const largeResponse = {
-				docs: Array(250)
-					.fill(mockDocument)
-					.map((_, i) => ({ ...mockDocument, id: `doc-${i}` })),
-				deleted: Array(10)
-					.fill('')
-					.map((_, i) => `deleted-doc-${i}`),
-			};
-
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 200,
-				json: largeResponse,
-				text: JSON.stringify(largeResponse),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			const result = await api.getAllDocuments();
-
-			expect(result).toHaveLength(250);
-			expect(requestUrl).toHaveBeenCalledTimes(1);
-
-			// Verify all documents have correct structure
-			result.forEach((doc, index) => {
-				expect(doc.id).toBe(`doc-${index}`);
-				expect(doc.title).toBe(mockDocument.title);
-			});
-		});
-	});
-
-	describe('user agent initialization edge cases', () => {
-		let originalFs: typeof import('fs');
-		let originalPath: typeof import('path');
-
-		beforeEach(() => {
-			// Store original modules
-			originalFs = require('fs');
-			originalPath = require('path');
-		});
-
-		afterEach(() => {
-			// Restore original modules
-			jest.resetModules();
-		});
-
-		it('should handle missing package.json file', () => {
-			// Mock fs.existsSync to return false
-			const mockFs = {
-				...originalFs,
-				existsSync: jest.fn().mockReturnValue(false),
-			};
-
-			// Mock require to return our mock fs
-			jest.doMock('fs', () => mockFs);
-
-			// Clear the module cache and re-require the API module
-			jest.resetModules();
-			const { GranolaAPI } = require('../../src/api');
-
-			// Create new instance - should use fallback user agent
-			const apiWithMissingPackage = new GranolaAPI(mockAuth);
-
-			// Access the private userAgent property
-			expect((apiWithMissingPackage as any).userAgent).toBe(
-				'obsidian-granola-importer/1.0.0'
-			);
-		});
-
-		it('should handle malformed package.json file', () => {
-			const mockFs = {
-				...originalFs,
-				existsSync: jest.fn().mockReturnValue(true),
-				readFileSync: jest
-					.fn()
-					.mockReturnValue('{"invalid": "json", "missing": "required fields"}'),
-			};
-
-			jest.doMock('fs', () => mockFs);
-
-			jest.resetModules();
-			const { GranolaAPI } = require('../../src/api');
-
-			// Create new instance - should use fallback user agent due to missing name/version
-			const apiWithMalformedPackage = new GranolaAPI(mockAuth);
-
-			expect((apiWithMalformedPackage as any).userAgent).toBe(
-				'obsidian-granola-importer/1.0.0'
-			);
-		});
-
-		it('should handle package.json with null name or version', () => {
-			const mockFs = {
-				...originalFs,
-				existsSync: jest.fn().mockReturnValue(true),
-				readFileSync: jest.fn().mockReturnValue('{"name": null, "version": "1.0.0"}'),
-			};
-
-			jest.doMock('fs', () => mockFs);
-
-			jest.resetModules();
-			const { GranolaAPI } = require('../../src/api');
-
-			// Create new instance - should use fallback user agent due to null name
-			const apiWithNullFields = new GranolaAPI(mockAuth);
-
-			expect((apiWithNullFields as any).userAgent).toBe('obsidian-granola-importer/1.0.0');
-		});
-
-		it('should handle package.json read errors', () => {
-			const mockFs = {
-				...originalFs,
-				existsSync: jest.fn().mockReturnValue(true),
-				readFileSync: jest.fn().mockImplementation(() => {
-					throw new Error('Permission denied');
-				}),
-			};
-
-			jest.doMock('fs', () => mockFs);
-
-			jest.resetModules();
-			const { GranolaAPI } = require('../../src/api');
-
-			// Create new instance - should use fallback user agent due to read error
-			const apiWithReadError = new GranolaAPI(mockAuth);
-
-			expect((apiWithReadError as any).userAgent).toBe('obsidian-granola-importer/1.0.0');
-		});
-
-		it('should handle JSON parsing errors', () => {
-			const mockFs = {
-				...originalFs,
-				existsSync: jest.fn().mockReturnValue(true),
-				readFileSync: jest.fn().mockReturnValue('invalid json content'),
-			};
-
-			jest.doMock('fs', () => mockFs);
-
-			jest.resetModules();
-			const { GranolaAPI } = require('../../src/api');
-
-			// Create new instance - should use fallback user agent due to JSON parse error
-			const apiWithParseError = new GranolaAPI(mockAuth);
-
-			expect((apiWithParseError as any).userAgent).toBe('obsidian-granola-importer/1.0.0');
-		});
-
-		it('should correctly parse valid package.json', () => {
-			const mockFs = {
-				...originalFs,
-				existsSync: jest.fn().mockReturnValue(true),
-				readFileSync: jest
-					.fn()
-					.mockReturnValue('{"name": "test-package", "version": "2.1.0"}'),
-			};
-
-			jest.doMock('fs', () => mockFs);
-
-			jest.resetModules();
-			const { GranolaAPI } = require('../../src/api');
-
-			// Create new instance - should use package.json values
-			const apiWithValidPackage = new GranolaAPI(mockAuth);
-
-			expect((apiWithValidPackage as any).userAgent).toBe('test-package/2.1.0');
-		});
-	});
-
-	describe('maximum retry attempts reached', () => {
-		it('should throw error when maximum retry attempts exceeded', async () => {
-			// Mock requestUrl to always return 429 (rate limited)
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 429,
-				json: { error: 'Rate limited' },
-				text: JSON.stringify({ error: 'Rate limited' }),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			// Should fail after max retries with rate limit error (not maximum retry error for 429s)
-			await expect(api.getDocuments()).rejects.toThrow(
-				'Rate limit exceeded. Please try again later.'
-			);
-
-			// Should have attempted the maximum number of retries (3)
-			expect(requestUrl).toHaveBeenCalledTimes(3);
-		});
-
-		it('should handle non-429 errors without retry', async () => {
-			// Mock requestUrl to return 500 error (not rate limited)
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 500,
-				json: { error: 'Server error' },
-				text: JSON.stringify({ error: 'Server error' }),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			// Should fail immediately without retries for non-429 errors
-			await expect(api.getDocuments()).rejects.toThrow('API request failed: 500');
-
-			// Should only be called once (no retries for non-429)
-			expect(requestUrl).toHaveBeenCalledTimes(1);
-		});
-	});
-
-	describe('comprehensive error handling', () => {
-		it('should handle network failures during retry', async () => {
-			const mockResponse = {
-				docs: [
-					{
-						id: 'test-doc-1',
-						title: 'Test Document',
-						created_at: '2023-01-01T00:00:00Z',
-						updated_at: '2023-01-01T00:00:00Z',
-						user_id: 'user-123',
+		expect(response.docs[0].people).toMatchObject({
+			creator: { name: 'Alex Smith', email: 'alex@example.com' },
+			attendees: [
+				{
+					email: 'sam@acme.com',
+					details: {
+						person: { name: { fullName: 'Sam Lee' } },
+						company: { name: 'Acme' },
 					},
-				],
-			};
+				},
+			],
+		});
+	});
 
-			(requestUrl as jest.MockedFunction<typeof requestUrl>)
-				.mockRejectedValueOnce(new Error('Network error'))
-				.mockResolvedValueOnce({
-					status: 200,
-					json: mockResponse,
-					text: JSON.stringify(mockResponse),
-					headers: {},
-					arrayBuffer: new ArrayBuffer(0),
-				});
+	it('fetches all listed meetings without the default page size cap', async () => {
+		const docs = await api.getAllDocuments();
 
-			const result = await api.getDocuments();
+		expect(docs).toHaveLength(2);
+		expect(docs.map(doc => doc.id)).toEqual(['meeting-1', 'meeting-2']);
+	});
 
-			expect(result).toEqual(mockResponse);
-			expect(requestUrl).toHaveBeenCalledTimes(2); // Initial + 1 retry
+	it('supports custom pagination offsets for connection tests', async () => {
+		const response = await api.getDocuments({ limit: 1, offset: 1 });
+
+		expect(response.docs).toHaveLength(1);
+		expect(mockCallTool).toHaveBeenLastCalledWith({
+			name: 'get_meetings',
+			arguments: { meeting_ids: ['meeting-2'] },
+		});
+	});
+
+	it('throws when Granola does not advertise required tools', async () => {
+		mockListTools.mockResolvedValue({ tools: [{ name: 'query_granola_meetings' }] });
+
+		await expect(api.getAllDocuments()).rejects.toThrow(
+			'Granola MCP tool "list_meetings" is unavailable'
+		);
+	});
+
+	it('surfaces MCP tool errors', async () => {
+		mockCallTool.mockImplementation(({ name }) => {
+			if (name === 'list_meetings') {
+				return Promise.resolve(toolText('rate limited', true));
+			}
+			return Promise.resolve(toolText(detailsResponse));
 		});
 
-		it('should handle authentication token refresh scenarios', async () => {
-			// Mock auth to simulate token refresh
-			let tokenCallCount = 0;
-			const mockAuthWithRefresh = {
-				...mockAuth,
-				getBearerToken: jest.fn().mockImplementation(() => {
-					tokenCallCount++;
-					return tokenCallCount === 1 ? 'expired-token' : 'fresh-token';
-				}),
-			};
+		await expect(api.getAllDocuments()).rejects.toThrow('rate limited');
+	});
 
-			const apiWithTokenRefresh = new GranolaAPI(mockAuthWithRefresh);
+	it('finishes OAuth and reconnects', async () => {
+		await api.finishAuth('authorization-code');
 
-			// Mock first call to fail with 401 (Unauthorized)
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 401,
-				json: { error: 'Invalid token' },
-				text: JSON.stringify({ error: 'Invalid token' }),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
+		expect(mockFinishAuth).toHaveBeenCalledWith('authorization-code');
+		expect(mockConnect).toHaveBeenCalledTimes(1);
+	});
 
-			// Should fail with 401 since we don't implement automatic token refresh
-			await expect(apiWithTokenRefresh.getDocuments()).rejects.toThrow(
-				'API request failed: 401'
-			);
-		});
+	it('disconnects the MCP client', async () => {
+		await api.loadCredentials();
+		await api.disconnect();
 
-		it('should handle partial response data corruption', async () => {
-			const corruptedResponse = {
-				docs: [
-					mockDocument, // Valid document
-					{ ...mockDocument, id: null }, // Corrupted document
-					mockDocument, // Valid document
-				],
-			};
-
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 200,
-				json: corruptedResponse,
-				text: JSON.stringify(corruptedResponse),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			const result = await api.getDocuments();
-
-			// Should still return the response even with corrupted data
-			expect(result).toEqual(corruptedResponse);
-			expect(result.docs).toHaveLength(3);
-		});
-
-		it('should handle extremely large payloads', async () => {
-			const hugeResponse = {
-				docs: Array(1000)
-					.fill(mockDocument)
-					.map((_, i) => ({
-						...mockDocument,
-						id: `doc-${i}`,
-						title: `Document ${i}`.repeat(100), // Make each title large
-					})),
-			};
-
-			(requestUrl as jest.MockedFunction<typeof requestUrl>).mockResolvedValue({
-				status: 200,
-				json: hugeResponse,
-				text: JSON.stringify(hugeResponse),
-				headers: {},
-				arrayBuffer: new ArrayBuffer(0),
-			});
-
-			const result = await api.getDocuments();
-
-			expect(result.docs).toHaveLength(1000);
-			expect(result.docs[0].title).toContain('Document 0');
-		});
+		expect(mockClose).toHaveBeenCalledTimes(1);
+		expect(api.isConnected).toBe(false);
 	});
 });

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -1,261 +1,156 @@
-import { jest } from '@jest/globals';
-import { GranolaAuth } from '../../src/auth';
-import {
-	mockCredentials,
-	mockCognitoTokens,
-	mockSupabaseConfig,
-	mockExpiredCognitoTokens,
-	mockInvalidTokenFormat,
-} from '../helpers';
+import { GranolaAuth, GranolaAuthData, GranolaAuthStorage } from '../../src/auth';
 
-// Mock the fs module (synchronous version used by auth.ts)
-jest.mock('fs', () => ({
-	readFileSync: jest.fn(),
-	existsSync: jest.fn(),
-}));
+function createStorage(initialData: GranolaAuthData = {}) {
+	let data: GranolaAuthData & Record<string, unknown> = { ...initialData };
+	const storage: GranolaAuthStorage = {
+		getData: jest.fn(async () => data),
+		saveData: jest.fn(async nextData => {
+			data = { ...nextData };
+		}),
+		openUrl: jest.fn(),
+	};
 
-// Mock os module
-jest.mock('os', () => ({
-	platform: jest.fn(),
-	homedir: jest.fn(),
-}));
-
-// Mock path module
-jest.mock('path', () => ({
-	join: jest.fn(),
-}));
-
-// Import the mocked modules to get the mocked functions
-import { readFileSync, existsSync } from 'fs';
-import { platform as osPlatform, homedir } from 'os';
-import { join } from 'path';
-
-const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
-const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
-const mockPlatform = osPlatform as jest.MockedFunction<typeof osPlatform>;
-const mockHomedir = homedir as jest.MockedFunction<typeof homedir>;
-const mockJoin = join as jest.MockedFunction<typeof join>;
+	return {
+		storage,
+		get data() {
+			return data;
+		},
+	};
+}
 
 describe('GranolaAuth', () => {
-	let auth: GranolaAuth;
+	it('exposes MCP OAuth client metadata', () => {
+		const auth = new GranolaAuth();
 
-	beforeEach(() => {
-		// Clear all mocks
-		jest.clearAllMocks();
-
-		// Setup mocks with proper values
-		mockReadFileSync.mockReturnValue(mockSupabaseConfig);
-		mockPlatform.mockReturnValue('darwin');
-		mockHomedir.mockReturnValue('/Users/test');
-		mockJoin.mockImplementation((...args: string[]) => args.join('/'));
-
-		// Create auth instance
-		auth = new GranolaAuth();
-	});
-
-	describe('loadCredentials', () => {
-		it('should load valid credentials successfully', async () => {
-			const credentials = await auth.loadCredentials();
-
-			expect(credentials).toEqual({
-				access_token: mockCognitoTokens.access_token,
-				refresh_token: mockCognitoTokens.refresh_token,
-				token_type: 'bearer', // normalized to lowercase
-				expires_at: expect.any(Number),
-			});
-		});
-
-		it('should cache credentials on subsequent calls', async () => {
-			await auth.loadCredentials();
-			await auth.loadCredentials();
-
-			expect(mockReadFileSync).toHaveBeenCalledTimes(1);
-		});
-
-		it('should throw error if config file is missing', async () => {
-			mockReadFileSync.mockImplementation(() => {
-				throw new Error('File not found');
-			});
-
-			await expect(auth.loadCredentials()).rejects.toThrow(
-				'Cannot read Granola configuration file'
-			);
-		});
-
-		it('should throw error if config file contains invalid JSON', async () => {
-			mockReadFileSync.mockReturnValue('invalid json');
-
-			await expect(auth.loadCredentials()).rejects.toThrow(
-				'Failed to load Granola credentials'
-			);
-		});
-
-		it('should throw error if required fields are missing', async () => {
-			const invalidConfig = {
-				cognito_tokens: JSON.stringify({ access_token: 'test' }), // missing other fields
-				user_info: '{}',
-			};
-			mockReadFileSync.mockReturnValue(JSON.stringify(invalidConfig));
-
-			await expect(auth.loadCredentials()).rejects.toThrow('Missing required field');
-		});
-
-		it('should throw error if token type is not bearer', async () => {
-			const invalidConfig = {
-				cognito_tokens: JSON.stringify({
-					...mockCognitoTokens,
-					token_type: 'basic',
-				}),
-				user_info: '{}',
-			};
-			mockReadFileSync.mockReturnValue(JSON.stringify(invalidConfig));
-
-			await expect(auth.loadCredentials()).rejects.toThrow('Invalid token type');
-		});
-
-		it('should throw error if token format is invalid', async () => {
-			const invalidConfig = {
-				cognito_tokens: JSON.stringify(mockInvalidTokenFormat),
-				user_info: '{}',
-			};
-			mockReadFileSync.mockReturnValue(JSON.stringify(invalidConfig));
-
-			await expect(auth.loadCredentials()).rejects.toThrow('Invalid token format');
-		});
-
-		it('should throw error if token is expired', async () => {
-			const expiredConfig = {
-				cognito_tokens: JSON.stringify(mockExpiredCognitoTokens),
-				user_info: '{}',
-			};
-			mockReadFileSync.mockReturnValue(JSON.stringify(expiredConfig));
-
-			await expect(auth.loadCredentials()).rejects.toThrow('Access token has expired');
+		expect(auth.redirectUrl).toBe('obsidian://granola-auth');
+		expect(auth.clientMetadata).toEqual({
+			client_name: 'Obsidian Granola Importer',
+			redirect_uris: ['obsidian://granola-auth'],
+			grant_types: ['authorization_code', 'refresh_token'],
+			response_types: ['code'],
+			token_endpoint_auth_method: 'none',
 		});
 	});
 
-	describe('getSupabaseConfigPath', () => {
-		it('should return correct path for macOS', () => {
-			mockPlatform.mockReturnValue('darwin');
-			mockHomedir.mockReturnValue('/Users/test');
+	it('persists OAuth tokens with an absolute expiry', async () => {
+		const fixture = createStorage();
+		const auth = new GranolaAuth(fixture.storage);
 
-			// Access the private method through any casting
-			const configPath = (auth as any).getSupabaseConfigPath();
-
-			expect(mockJoin).toHaveBeenCalledWith(
-				'/Users/test',
-				'Library',
-				'Application Support',
-				'Granola',
-				'supabase.json'
-			);
+		await auth.saveTokens({
+			access_token: 'access-token',
+			refresh_token: 'refresh-token',
+			token_type: 'Bearer',
+			expires_in: 3600,
 		});
 
-		it('should return correct path for Windows', () => {
-			mockPlatform.mockReturnValue('win32');
-			mockHomedir.mockReturnValue('C:\\Users\\test');
-
-			const configPath = (auth as any).getSupabaseConfigPath();
-
-			expect(mockJoin).toHaveBeenCalledWith(
-				'C:\\Users\\test',
-				'AppData',
-				'Roaming',
-				'Granola',
-				'supabase.json'
-			);
-		});
-
-		it('should return correct path for Linux', () => {
-			mockPlatform.mockReturnValue('linux');
-			mockHomedir.mockReturnValue('/home/test');
-
-			const configPath = (auth as any).getSupabaseConfigPath();
-
-			expect(mockJoin).toHaveBeenCalledWith(
-				'/home/test',
-				'.config',
-				'Granola',
-				'supabase.json'
-			);
-		});
-
-		it('should throw error for unsupported platform', () => {
-			mockPlatform.mockReturnValue('freebsd');
-
-			expect(() => (auth as any).getSupabaseConfigPath()).toThrow('Unsupported platform');
+		expect(fixture.storage.saveData).toHaveBeenCalled();
+		expect(fixture.data.oauthTokens).toMatchObject({
+			access_token: 'access-token',
+			refresh_token: 'refresh-token',
+			token_type: 'Bearer',
+			expires_in: 3600,
+			obtained_at: expect.any(Number),
+			expires_at: expect.any(Number),
 		});
 	});
 
-	describe('getBearerToken', () => {
-		it('should return access token when credentials are loaded', async () => {
-			await auth.loadCredentials();
-			const token = auth.getBearerToken();
-
-			expect(token).toBe(mockCredentials.access_token);
+	it('loads credentials from persisted tokens', async () => {
+		const { storage } = createStorage({
+			oauthTokens: {
+				access_token: 'access-token',
+				refresh_token: 'refresh-token',
+				token_type: 'Bearer',
+				expires_at: Math.floor(Date.now() / 1000) + 3600,
+			},
 		});
+		const auth = new GranolaAuth(storage);
 
-		it('should throw error when credentials are not loaded', () => {
-			expect(() => auth.getBearerToken()).toThrow('Credentials not loaded');
+		const credentials = await auth.loadCredentials();
+
+		expect(credentials).toEqual({
+			access_token: 'access-token',
+			refresh_token: 'refresh-token',
+			token_type: 'bearer',
+			expires_at: expect.any(Number),
 		});
+		expect(auth.getBearerToken()).toBe('access-token');
+		expect(auth.hasValidCredentials()).toBe(true);
 	});
 
-	describe('isTokenExpired', () => {
-		it('should return false for valid token', async () => {
-			await auth.loadCredentials();
+	it('rejects missing tokens', async () => {
+		const { storage } = createStorage();
+		const auth = new GranolaAuth(storage);
 
-			expect(auth.isTokenExpired()).toBe(false);
-		});
-
-		it('should return true when credentials are not loaded', () => {
-			expect(auth.isTokenExpired()).toBe(true);
-		});
+		await expect(auth.loadCredentials()).rejects.toThrow('Granola account is not connected');
+		expect(() => auth.getBearerToken()).toThrow('Credentials not loaded');
 	});
 
-	describe('hasValidCredentials', () => {
-		it('should return true when credentials are loaded and valid', async () => {
-			await auth.loadCredentials();
-
-			expect(auth.hasValidCredentials()).toBe(true);
+	it('rejects invalid token types', async () => {
+		const { storage } = createStorage({
+			oauthTokens: {
+				access_token: 'access-token',
+				token_type: 'Basic',
+			},
 		});
+		const auth = new GranolaAuth(storage);
 
-		it('should return false when credentials are not loaded', () => {
-			expect(auth.hasValidCredentials()).toBe(false);
-		});
+		await expect(auth.loadCredentials()).rejects.toThrow('Invalid token type: Basic');
 	});
 
-	describe('clearCredentials', () => {
-		it('should clear cached credentials', async () => {
-			await auth.loadCredentials();
-			expect(auth.hasValidCredentials()).toBe(true);
+	it('persists dynamic client registration and PKCE verifier', async () => {
+		const fixture = createStorage();
+		const auth = new GranolaAuth(fixture.storage);
 
-			auth.clearCredentials();
-			expect(auth.hasValidCredentials()).toBe(false);
-		});
+		await auth.saveClientInformation({ client_id: 'client-id' });
+		await auth.saveCodeVerifier('verifier');
+
+		expect(await auth.clientInformation()).toEqual({ client_id: 'client-id' });
+		expect(await auth.codeVerifier()).toBe('verifier');
+		expect(fixture.data.oauthClientInfo).toEqual({ client_id: 'client-id' });
+		expect(fixture.data.oauthCodeVerifier).toBe('verifier');
 	});
 
-	describe('refreshToken', () => {
-		it('should throw error as refresh is not implemented', async () => {
-			await auth.loadCredentials();
+	it('opens browser authorization URLs through storage', async () => {
+		const { storage } = createStorage();
+		const auth = new GranolaAuth(storage);
 
-			expect(() => auth.refreshToken()).toThrow('Token refresh not yet implemented');
+		await auth.redirectToAuthorization(new URL('https://mcp.granola.ai/auth'));
+
+		expect(storage.openUrl).toHaveBeenCalledWith('https://mcp.granola.ai/auth');
+	});
+
+	it('clears persisted OAuth state', async () => {
+		const fixture = createStorage({
+			oauthTokens: {
+				access_token: 'access-token',
+				token_type: 'Bearer',
+			},
+			oauthClientInfo: { client_id: 'client-id' },
+			oauthCodeVerifier: 'verifier',
 		});
+		const auth = new GranolaAuth(fixture.storage);
+		await auth.loadCredentials();
 
-		it('should throw error when no refresh token available', () => {
-			expect(() => auth.refreshToken()).toThrow('No refresh token available');
+		await auth.clearCredentials();
+
+		expect(auth.hasValidCredentials()).toBe(false);
+		expect(fixture.data.oauthTokens).toBeUndefined();
+		expect(fixture.data.oauthClientInfo).toBeUndefined();
+		expect(fixture.data.oauthCodeVerifier).toBeUndefined();
+	});
+
+	it('marks cached tokens expired using the stored expiry', async () => {
+		const { storage } = createStorage({
+			oauthTokens: {
+				access_token: 'access-token',
+				token_type: 'Bearer',
+				expires_at: Math.floor(Date.now() / 1000) - 1,
+			},
 		});
+		const auth = new GranolaAuth(storage);
+		await auth.loadCredentials();
 
-		it('should clear credentials on refresh failure', async () => {
-			await auth.loadCredentials();
-			expect(auth.hasValidCredentials()).toBe(true);
-
-			try {
-				auth.refreshToken();
-			} catch {
-				// Expected to fail
-			}
-
-			expect(auth.hasValidCredentials()).toBe(false);
-		});
+		expect(auth.isTokenExpired()).toBe(true);
+		expect(auth.hasValidCredentials()).toBe(false);
 	});
 });

--- a/tests/unit/fetch.test.ts
+++ b/tests/unit/fetch.test.ts
@@ -1,0 +1,150 @@
+import { createServer, Server } from 'node:http';
+import { nodeFetch } from '../../src/fetch';
+
+function listen(server: Server): Promise<number> {
+	return new Promise(resolve => {
+		server.listen(0, () => {
+			const address = server.address();
+			if (typeof address === 'object' && address?.port) {
+				resolve(address.port);
+			}
+		});
+	});
+}
+
+function close(server: Server): Promise<void> {
+	return new Promise(resolve => {
+		const timeout = setTimeout(resolve, 100);
+		server.close(() => {
+			clearTimeout(timeout);
+			resolve();
+		});
+		server.closeAllConnections?.();
+		server.closeIdleConnections?.();
+	});
+}
+
+describe('nodeFetch', () => {
+	let server: Server;
+	let baseUrl: string;
+
+	afterEach(async () => {
+		if (server.listening) {
+			await close(server);
+		}
+	});
+
+	it('performs basic GET requests and exposes response headers', async () => {
+		let requestedPath = '';
+		server = createServer((req, res) => {
+			expect(req.method).toBe('GET');
+			requestedPath = req.url ?? '';
+			res.setHeader('x-test-header', 'ok');
+			res.end('hello');
+		});
+		baseUrl = `http://127.0.0.1:${await listen(server)}`;
+
+		const response = await nodeFetch(`${baseUrl}/hello`);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('x-test-header')).toBe('ok');
+		expect(requestedPath).toBe('/hello');
+	});
+
+	it('follows redirects', async () => {
+		let hitTarget = false;
+		server = createServer((req, res) => {
+			if (req.url === '/redirect') {
+				res.statusCode = 302;
+				res.setHeader('location', '/target');
+				res.end();
+				return;
+			}
+
+			hitTarget = true;
+			res.end('target');
+		});
+		baseUrl = `http://127.0.0.1:${await listen(server)}`;
+
+		const response = await nodeFetch(`${baseUrl}/redirect`);
+
+		expect(response.status).toBe(200);
+		expect(hitTarget).toBe(true);
+	});
+
+	it('sends string request bodies with content length', async () => {
+		let resolveReceived: (value: string) => void;
+		const received = new Promise<string>(resolve => {
+			resolveReceived = resolve;
+		});
+		server = createServer((req, res) => {
+			let body = '';
+			req.on('data', chunk => {
+				body += chunk.toString();
+			});
+			req.on('end', () => {
+				resolveReceived(`${req.headers['content-length']}:${body}`);
+				res.end(`${req.headers['content-length']}:${body}`);
+			});
+		});
+		baseUrl = `http://127.0.0.1:${await listen(server)}`;
+
+		const response = await nodeFetch(`${baseUrl}/echo`, {
+			method: 'POST',
+			body: 'payload',
+		});
+
+		expect(response.status).toBe(200);
+		await expect(received).resolves.toBe('7:payload');
+	});
+
+	it('supports URLSearchParams and ArrayBuffer bodies', async () => {
+		const bodies: string[] = [];
+		let resolveReceived: () => void;
+		const received = new Promise<void>(resolve => {
+			resolveReceived = resolve;
+		});
+		server = createServer((req, res) => {
+			let body = '';
+			req.on('data', chunk => {
+				body += chunk.toString();
+			});
+			req.on('end', () => {
+				bodies.push(body);
+				if (bodies.length === 2) {
+					resolveReceived();
+				}
+				res.end('ok');
+			});
+		});
+		baseUrl = `http://127.0.0.1:${await listen(server)}`;
+
+		await nodeFetch(`${baseUrl}/form`, {
+			method: 'POST',
+			body: new URLSearchParams({ q: 'granola' }),
+		});
+		const bytes = new Uint8Array([98, 121, 116, 101, 115]);
+		await nodeFetch(`${baseUrl}/buffer`, {
+			method: 'POST',
+			body: bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+		});
+
+		await received;
+		expect(bodies).toEqual(['q=granola', 'bytes']);
+	});
+
+	it('rejects immediately when called with an aborted signal', async () => {
+		server = createServer((_req, res) => {
+			res.end('unreachable');
+		});
+		baseUrl = `http://127.0.0.1:${await listen(server)}`;
+		const controller = new AbortController();
+		controller.abort();
+
+		await expect(
+			nodeFetch(`${baseUrl}/aborted`, {
+				signal: controller.signal,
+			})
+		).rejects.toThrow('The operation was aborted');
+	});
+});

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -661,6 +661,7 @@ describe('GranolaSettingTab class', () => {
 				loadCredentials: jest.fn().mockResolvedValue(undefined),
 			},
 			api: {
+				loadCredentials: jest.fn().mockResolvedValue(undefined),
 				getDocuments: jest.fn().mockResolvedValue({ docs: [] }),
 			},
 			logger: {
@@ -758,7 +759,7 @@ describe('GranolaSettingTab class', () => {
 
 			await (settingTab as any).validateConnection(mockStatusEl);
 
-			expect(mockPlugin.auth.loadCredentials).toHaveBeenCalled();
+			expect(mockPlugin.api.loadCredentials).toHaveBeenCalled();
 			expect(mockPlugin.api.getDocuments).toHaveBeenCalledWith({ limit: 1, offset: 0 });
 			expect(mockPlugin.settings.connection.isConnected).toBe(true);
 			expect(mockPlugin.saveSettings).toHaveBeenCalled();
@@ -902,7 +903,7 @@ describe('GranolaSettingTab class', () => {
 				expect(callbacks.buttonCallbacks.length).toBeGreaterThan(0);
 				await callbacks.buttonCallbacks[0]();
 
-				expect(mockPlugin.auth.loadCredentials).toHaveBeenCalled();
+				expect(mockPlugin.api.loadCredentials).toHaveBeenCalled();
 			});
 		});
 
@@ -1137,7 +1138,7 @@ describe('GranolaSettingTab class', () => {
 				expect(mockStatusEl._content).toContain('Connection failed');
 			});
 
-			it('should handle auth.loadCredentials failure', async () => {
+			it('should handle api.loadCredentials failure', async () => {
 				const mockStatusEl = {
 					_content: '',
 					empty: jest.fn(() => {
@@ -1152,7 +1153,7 @@ describe('GranolaSettingTab class', () => {
 						mockStatusEl._content += text;
 					}),
 				};
-				mockPlugin.auth.loadCredentials = jest
+				mockPlugin.api.loadCredentials = jest
 					.fn()
 					.mockRejectedValue(new Error('Auth failed'));
 


### PR DESCRIPTION
## Summary

Migrates the Granola integration from the old REST/desktop-token path to Granola MCP over streamable HTTP with OAuth. The plugin now opens the browser-based Granola authorization flow, receives the `obsidian://granola-auth` callback in Obsidian, persists OAuth tokens/client registration in plugin data, and uses MCP tool discovery plus meeting list/fetch tool calls for imports.

## What changed

- Replaced `src/auth.ts` with an MCP OAuth provider backed by Obsidian plugin data.
- Replaced `src/api.ts` with an MCP JSON-RPC client over streamable HTTP.
- Added a Node fetch adapter for the MCP SDK.
- Kept converter/services/UI/frontmatter/settings behavior, with Markdown fallback for MCP responses.
- Updated auth/API/settings tests and added fetch adapter coverage.
- Cleared npm audit advisories by upgrading dev tooling and patching the pre-commit hook for Jest 30.

## User impact

Users authenticate through Granola in their browser. After approval, Granola redirects to `obsidian://granola-auth`, Obsidian routes that callback to the plugin, and the plugin exchanges the OAuth code for stored tokens before continuing import.

## Validation

- `npm run format:check`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm test -- --coverage --runInBand` (17 suites / 412 tests)
- `npm audit` (0 vulnerabilities)
- Pre-commit hook passed on commit
- Live MCP boundary check reached Granola OAuth discovery/dynamic registration and returned an auth URL; authenticated tool calls require completing the interactive browser-to-Obsidian callback.